### PR TITLE
module: move daemon start exclusively to service.sh

### DIFF
--- a/daemon/src/main/java/org/lsposed/lspd/service/ServiceManager.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/ServiceManager.java
@@ -95,9 +95,7 @@ public class ServiceManager {
 
         int systemServerMaxRetry = 1;
         for (String arg : args) {
-            if (arg.equals("--from-service")) {
-                Log.w(TAG, "LSPosed daemon is not started properly. Try for a late start...");
-            } else if (arg.startsWith("--system-server-max-retry=")) {
+            if (arg.startsWith("--system-server-max-retry=")) {
                 try {
                     systemServerMaxRetry = Integer.parseInt(arg.substring(arg.lastIndexOf('=') + 1));
                 } catch (Throwable ignored) {

--- a/magisk-loader/magisk_module/post-fs-data.sh
+++ b/magisk-loader/magisk_module/post-fs-data.sh
@@ -21,6 +21,4 @@ MODDIR=${0%/*}
 
 rm -f "/data/local/tmp/daemon.apk"
 rm -f "/data/local/tmp/manager.apk"
-cd "$MODDIR"
 
-unshare --propagation slave -m sh -c "$MODDIR/daemon $@&"

--- a/magisk-loader/magisk_module/service.sh
+++ b/magisk-loader/magisk_module/service.sh
@@ -18,6 +18,8 @@
 #
 
 MODDIR=${0%/*}
+
 cd "$MODDIR"
-# post-fs-data.sh may be blocked by other modules. retry to start this
-unshare --propagation slave -m sh -c "$MODDIR/daemon --from-service $@&"
+
+# Start daemon in service.sh as early start can cause Play Integrity detection
+unshare --propagation slave -m sh -c "$MODDIR/daemon $@&"


### PR DESCRIPTION
Starting daemon during post-fs-data can cause Play Integrity detection for devices that do not need to use a Play Integrity Fix module.