### PR TITLE
Fix Manager Dynamic Colors

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -117,7 +117,8 @@ materialThemeBuilder {
         }
     }
     // Add Material Design 3 color tokens (such as palettePrimary100) in generated theme
-    // rikka.material >= 2.0.0 provides such attributes
+    // rikka.material:material >= 2.0.0 provides such attributes
+    // Enable this if your are using rikka.material:material
     generatePalette = true
 }
 
@@ -144,7 +145,6 @@ dependencies {
     implementation(libs.rikkax.insets)
     implementation(libs.rikkax.material)
     implementation(libs.rikkax.material.preference)
-    implementation(libs.rikkax.preference)
     implementation(libs.rikkax.recyclerview)
     implementation(libs.rikkax.widget.borderview)
     implementation(libs.rikkax.widget.mainswitchbar)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,7 +71,7 @@ val androidTargetSdkVersion by extra(35)
 val androidMinSdkVersion by extra(27)
 val androidBuildToolsVersion by extra("35.0.0")
 val androidCompileSdkVersion by extra(35)
-val androidCompileNdkVersion by extra("27.0.12077973")
+val androidCompileNdkVersion by extra("27.1.12297006")
 val androidSourceCompatibility by extra(JavaVersion.VERSION_21)
 val androidTargetCompatibility by extra(JavaVersion.VERSION_21)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ agp-app = { id = "com.android.application", version.ref = "agp" }
 kotlin = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 nav-safeargs = { id = "androidx.navigation.safeargs", version.ref = "nav" }
 autoresconfig = { id = "dev.rikka.tools.autoresconfig", version = "1.2.2" }
-materialthemebuilder = { id = "dev.rikka.tools.materialthemebuilder", version = "1.4.1" }
+materialthemebuilder = { id = "dev.rikka.tools.materialthemebuilder", version = "1.5.1" }
 lsplugin-resopt = { id = "org.lsposed.lsplugin.resopt", version = "1.6" }
 lsplugin-apksign = { id = "org.lsposed.lsplugin.apksign", version = "1.4" }
 lsplugin-cmaker = { id = "org.lsposed.lsplugin.cmaker", version = "1.2" }
@@ -27,10 +27,9 @@ rikkax-appcompat = { module = "dev.rikka.rikkax.appcompat:appcompat", version = 
 rikkax-core = { module = "dev.rikka.rikkax.core:core", version = "1.4.1" }
 rikkax-insets = { module = "dev.rikka.rikkax.insets:insets", version = "1.3.0" }
 rikkax-layoutinflater = { module = "dev.rikka.rikkax.layoutinflater:layoutinflater", version = "1.3.0" }
-rikkax-material = { module = "dev.rikka.rikkax.material:material", version = "2.7.0" }
+rikkax-material = { module = "dev.rikka.rikkax.material:material", version = "2.7.2" }
 rikkax-material-preference = { module = "dev.rikka.rikkax.material:material-preference", version = "2.0.0" }
 rikkax-parcelablelist = { module = "dev.rikka.rikkax.parcelablelist:parcelablelist", version = "2.0.1" }
-rikkax-preference = { module = "dev.rikka.rikkax.material:material-preference", version = "2.0.0" }
 rikkax-recyclerview = { module = "dev.rikka.rikkax.recyclerview:recyclerview-ktx", version = "1.3.2" }
 rikkax-widget-borderview = { module = "dev.rikka.rikkax.widget:borderview", version = "1.1.0" }
 rikkax-widget-mainswitchbar = { module = "dev.rikka.rikkax.widget:mainswitchbar", version = "1.0.2" }


### PR DESCRIPTION
Material updated the color overlay in 1.11.0, but rikkax-material has not been updated since then. 
But it was updated yesterday, so it can be fixed now.