### PR TITLE
Remove XposedBridge.log in XC_MethodReplacement

### DIFF
--- a/core/src/main/java/de/robv/android/xposed/XC_MethodReplacement.java
+++ b/core/src/main/java/de/robv/android/xposed/XC_MethodReplacement.java
@@ -51,7 +51,6 @@ public abstract class XC_MethodReplacement extends XC_MethodHook {
             Object result = replaceHookedMethod(param);
             param.setResult(result);
         } catch (Throwable t) {
-            XposedBridge.log(t);
             param.setThrowable(t);
         }
     }


### PR DESCRIPTION
There should be no log. It is intended to be used as a way to setThrowable(). The `XposedBridge.log(t)` doesn't exist in the original xposed API.
For example, if you call `invokeOriginalMethod()` in replaceHookedMethod(), throw the original throwable. It will still be logged, instead, it should be part of the normal process.