### PR TITLE
Fix SELinux issues

### DIFF
--- a/magisk-loader/magisk_module/sepolicy.rule
+++ b/magisk-loader/magisk_module/sepolicy.rule
@@ -1,1 +1,3 @@
 allow dex2oat dex2oat_exec file execute_no_trans
+
+allow shell shell dir write


### PR DESCRIPTION
In NeoZygisk, some unnecessary SELinux rules are removed in https://github.com/JingMatrix/NeoZygisk/commit/2d7362ca74831c7dadd29de250bb1d58fd4af4fb. To fix the compatibility issue, we add some rules back.