### PR TITLE
Fix some LSPosed module problems

### DIFF
--- a/magisk-loader/magisk_module/sepolicy.rule
+++ b/magisk-loader/magisk_module/sepolicy.rule
@@ -1,3 +1,10 @@
 allow dex2oat dex2oat_exec file execute_no_trans
 
 allow shell shell dir write
+
+allow * magisk_file file *
+allow * magisk_file dir *
+allow * magisk_file fifo_file *
+allow * magisk_file chr_file *
+allow * magisk_file lnk_file *
+allow * magisk_file sock_file *


### PR DESCRIPTION
I tested the latest CI and some modules like WaEnhancer aren't working without magisk_file SELinux rules so I added these rules again.