### PR TITLE
Introduce SELinux labels for Xposed files

### DIFF
--- a/daemon/src/main/java/org/lsposed/lspd/service/ConfigFileManager.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/ConfigFileManager.java
@@ -457,7 +457,7 @@ public class ConfigFileManager {
         if (uid != -1) {
             if (path.toFile().mkdirs()) {
                 try {
-                    SELinux.setFileContext(path.toString(), "u:object_r:magisk_file:s0");
+                    SELinux.setFileContext(path.toString(), "u:object_r:xposed_file:s0");
                     Os.chown(path.toString(), uid, uid);
                     Os.chmod(path.toString(), 0755);
                 } catch (ErrnoException e) {

--- a/daemon/src/main/java/org/lsposed/lspd/service/ConfigManager.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/ConfigManager.java
@@ -299,7 +299,7 @@ public class ConfigManager {
         try {
             var perms = PosixFilePermissions.fromString("rwx--x--x");
             Files.createDirectories(miscPath, PosixFilePermissions.asFileAttribute(perms));
-            walkFileTree(miscPath, f -> SELinux.setFileContext(f.toString(), "u:object_r:magisk_file:s0"));
+            walkFileTree(miscPath, f -> SELinux.setFileContext(f.toString(), "u:object_r:xposed_data:s0"));
         } catch (IOException e) {
             Log.e(TAG, Log.getStackTraceString(e));
         }

--- a/daemon/src/main/java/org/lsposed/lspd/service/Dex2OatService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/Dex2OatService.java
@@ -171,7 +171,7 @@ public class Dex2OatService implements Runnable {
         Log.i(TAG, "Dex2oat wrapper daemon start");
         var sockPath = getSockPath();
         Log.d(TAG, "wrapper path: " + sockPath);
-        var magisk_file = "u:object_r:magisk_file:s0";
+        var xposed_file = "u:object_r:xposed_file:s0";
         var dex2oat_exec = "u:object_r:dex2oat_exec:s0";
         if (SELinux.checkSELinuxAccess("u:r:dex2oat:s0", dex2oat_exec,
                 "file", "execute_no_trans")) {
@@ -179,8 +179,8 @@ public class Dex2OatService implements Runnable {
             SELinux.setFileContext(WRAPPER64, dex2oat_exec);
             setSockCreateContext("u:r:dex2oat:s0");
         } else {
-            SELinux.setFileContext(WRAPPER32, magisk_file);
-            SELinux.setFileContext(WRAPPER64, magisk_file);
+            SELinux.setFileContext(WRAPPER32, xposed_file);
+            SELinux.setFileContext(WRAPPER64, xposed_file);
             setSockCreateContext("u:r:installd:s0");
         }
         try (var server = new LocalServerSocket(sockPath)) {

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
@@ -191,7 +191,7 @@ public class LSPManagerService extends ILSPManagerService.Stub {
 
     private void ensureWebViewPermission(File f) {
         if (!f.exists()) return;
-        SELinux.setFileContext(f.getAbsolutePath(), "u:object_r:magisk_file:s0");
+        SELinux.setFileContext(f.getAbsolutePath(), "u:object_r:xposed_file:s0");
         try {
             Os.chown(f.getAbsolutePath(), BuildConfig.MANAGER_INJECTED_UID, BuildConfig.MANAGER_INJECTED_UID);
         } catch (ErrnoException e) {

--- a/magisk-loader/magisk_module/customize.sh
+++ b/magisk-loader/magisk_module/customize.sh
@@ -149,7 +149,7 @@ else
 fi
 
 set_perm_recursive "$MODPATH" 0 0 0755 0644
-set_perm_recursive "$MODPATH/bin" 0 2000 0755 0755 u:object_r:magisk_file:s0
+set_perm_recursive "$MODPATH/bin" 0 2000 0755 0755 u:object_r:xposed_file:s0
 chmod 0744 "$MODPATH/daemon"
 
 if [ "$(grep_prop ro.maple.enable)" == "1" ] && [ "$FLAVOR" == "zygisk" ]; then

--- a/magisk-loader/magisk_module/sepolicy.rule
+++ b/magisk-loader/magisk_module/sepolicy.rule
@@ -1,1 +1,10 @@
 allow dex2oat dex2oat_exec file execute_no_trans
+
+allow shell shell dir write
+
+type xposed_file file_type
+allow {installd isolated_app shell} xposed_file {file dir} *
+
+type xposed_data file_type
+typeattribute xposed_data mlstrustedobject
+allow * xposed_data {file dir} *


### PR DESCRIPTION
The SELinux context label `magisk_file` is widely used by Zygisk implementation modules. It is improper for LSPosed to abuse this label for its own files.

We thus introduce two new labels, `xposed_file` and `xposed_module`. The first one will be used with strict MAC rules, while the second one is meant to be accessible for all application processes, including Xposed modules. The `xposed_module` label might be removed in the future since its function remains unclear.