### PR TITLE
Allow dex2oat to read files received from sockets

### DIFF
--- a/magisk-loader/magisk_module/sepolicy.rule
+++ b/magisk-loader/magisk_module/sepolicy.rule
@@ -6,7 +6,7 @@ type xposed_file file_type
 typeattribute xposed_file mlstrustedobject
 allow {dex2oat installd isolated_app shell} xposed_file {file dir} *
 
-allow dex2oat unlabeled file open
+allow dex2oat unlabeled file *
 
 type xposed_data file_type
 typeattribute xposed_data mlstrustedobject

--- a/magisk-loader/magisk_module/sepolicy.rule
+++ b/magisk-loader/magisk_module/sepolicy.rule
@@ -6,6 +6,8 @@ type xposed_file file_type
 typeattribute xposed_file mlstrustedobject
 allow {dex2oat installd isolated_app shell} xposed_file {file dir} *
 
+allow dex2oat unlabeled file open
+
 type xposed_data file_type
 typeattribute xposed_data mlstrustedobject
 allow * xposed_data {file dir} *


### PR DESCRIPTION
On some devices `dex2oat` cannot access files received from sockets due to SELinux restrictions.
A new rule is added according to the avc logs.