### PR TITLE
Fix liboat_hook.so inaccessible in some device

### DIFF
--- a/daemon/src/main/java/org/lsposed/lspd/service/Dex2OatService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/Dex2OatService.java
@@ -50,6 +50,8 @@ public class Dex2OatService implements Runnable {
     private static final String TAG = "LSPosedDex2Oat";
     private static final String WRAPPER32 = "bin/dex2oat32";
     private static final String WRAPPER64 = "bin/dex2oat64";
+    private static final String HOOKER32 = "bin/liboat_hook32.so";
+    private static final String HOOKER64 = "bin/liboat_hook64.so";
 
     private final String[] dex2oatArray = new String[6];
     private final FileDescriptor[] fdArray = new FileDescriptor[6];
@@ -186,6 +188,8 @@ public class Dex2OatService implements Runnable {
             SELinux.setFileContext(WRAPPER64, xposed_file);
             setSockCreateContext("u:r:installd:s0");
         }
+        SELinux.setFileContext(HOOKER32, xposed_file);
+        SELinux.setFileContext(HOOKER64, xposed_file);
         try (var server = new LocalServerSocket(sockPath)) {
             setSockCreateContext(null);
             while (true) {

--- a/dex2oat/src/main/cpp/dex2oat.c
+++ b/dex2oat/src/main/cpp/dex2oat.c
@@ -131,11 +131,15 @@ int main(int argc, char **argv) {
         putenv((char *)libenv);
     }
 
-    // Set LD_PRELOAD to load liboat_hook.so
-    const int STRING_BUFFER = 50;
-    char env_str[STRING_BUFFER];
-    snprintf(env_str, STRING_BUFFER, "LD_PRELOAD=/proc/%d/fd/%d", getpid(), hooker_fd);
-    putenv(env_str);
+    if (hooker_fd > 0) {
+        // Set LD_PRELOAD to load liboat_hook.so
+        const int STRING_BUFFER = 50;
+        char env_str[STRING_BUFFER];
+        snprintf(env_str, STRING_BUFFER, "LD_PRELOAD=/proc/%d/fd/%d", getpid(), hooker_fd);
+        putenv(env_str);
+    } else {
+        LOGE("Unable to read liboat_hook.so");
+    }
 
     fexecve(stock_fd, (char **)new_argv, environ);
 

--- a/magisk-loader/magisk_module/sepolicy.rule
+++ b/magisk-loader/magisk_module/sepolicy.rule
@@ -2,9 +2,9 @@ allow dex2oat dex2oat_exec file execute_no_trans
 
 allow shell shell dir write
 
-type xposed_file file_type
+type xposed_file system_file_type
 typeattribute xposed_file mlstrustedobject
-allow {dex2oat installd isolated_app shell} {xposed_file adb_data_file} {file dir} *
+allow {dex2oat installd isolated_app shell} xposed_file {file dir} *
 
 allow dex2oat unlabeled file *
 

--- a/magisk-loader/magisk_module/sepolicy.rule
+++ b/magisk-loader/magisk_module/sepolicy.rule
@@ -4,7 +4,7 @@ allow shell shell dir write
 
 type xposed_file file_type
 typeattribute xposed_file mlstrustedobject
-allow {dex2oat installd isolated_app shell} xposed_file {file dir} *
+allow {dex2oat installd isolated_app shell} {xposed_file adb_data_file} {file dir} *
 
 allow dex2oat unlabeled file *
 

--- a/magisk-loader/magisk_module/sepolicy.rule
+++ b/magisk-loader/magisk_module/sepolicy.rule
@@ -2,7 +2,7 @@ allow dex2oat dex2oat_exec file execute_no_trans
 
 allow shell shell dir write
 
-type xposed_file system_file_type
+type xposed_file file_type
 typeattribute xposed_file mlstrustedobject
 allow {dex2oat installd isolated_app shell} xposed_file {file dir} *
 


### PR DESCRIPTION
User has reported `dex2oat` failure with SELinux log:

W dex2oat64: type=1400 audit(0.0:922): avc: denied { read } for path="/data/adb/modules/zygisk_lsposed/bin/liboat_hook64.so" dev="dm-58" ino=91204 scontext=u:r:dex2oat:s0 tcontext=u:object_r:adb_data_file:s0 tclass=file permissive=0