### PR TITLE
Bump the maven group across 1 directory with 7 updates (#174)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.8.0"
-kotlin = "2.1.0"
-nav = "2.8.5"
+kotlin = "2.1.10"
+nav = "2.8.6"
 appcenter = "5.0.5"
 libxposed = "100"
 glide = "4.16.0"
@@ -53,8 +53,8 @@ okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-i
 agp-apksig = { group = "com.android.tools.build", name = "apksig", version.ref = "agp" }
 appiconloader = { module = "me.zhanghai.android.appiconloader:appiconloader", version = "1.5.0" }
 material = { module = "com.google.android.material:material", version = "1.12.0" }
-gson = { module = "com.google.code.gson:gson", version = "2.11.0" }
-hiddenapibypass = { module = "org.lsposed.hiddenapibypass:hiddenapibypass", version = "4.3" }
+gson = { module = "com.google.code.gson:gson", version = "2.12.0" }
+hiddenapibypass = { module = "org.lsposed.hiddenapibypass:hiddenapibypass", version = "6.0" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.10.1" }
 


### PR DESCRIPTION
Bumps the maven group with 7 updates in the / directory:

| Package | From | To |
| --- | --- | --- |
| androidx.navigation:navigation-fragment | `2.8.5` | `2.8.6` | | androidx.navigation:navigation-ui | `2.8.5` | `2.8.6` | | androidx.navigation.safeargs | `2.8.5` | `2.8.6` | | [com.google.code.gson:gson](https://github.com/google/gson) | `2.11.0` | `2.12.0` | | [org.lsposed.hiddenapibypass:hiddenapibypass](https://github.com/LSPosed/AndroidHiddenApiBypass) | `4.3` | `6.0` | | [org.jetbrains.kotlin:kotlin-stdlib](https://github.com/JetBrains/kotlin) | `2.1.0` | `2.1.10` | | [org.jetbrains.kotlin.android](https://github.com/JetBrains/kotlin) | `2.1.0` | `2.1.10` |



Updates `androidx.navigation:navigation-fragment` from 2.8.5 to 2.8.6

Updates `androidx.navigation:navigation-ui` from 2.8.5 to 2.8.6

Updates `androidx.navigation.safeargs` from 2.8.5 to 2.8.6

Updates `androidx.navigation:navigation-ui` from 2.8.5 to 2.8.6

Updates `com.google.code.gson:gson` from 2.11.0 to 2.12.0
- [Release notes](https://github.com/google/gson/releases)
- [Changelog](https://github.com/google/gson/blob/main/CHANGELOG.md)
- [Commits](https://github.com/google/gson/compare/gson-parent-2.11.0...gson-parent-2.12.0)

Updates `org.lsposed.hiddenapibypass:hiddenapibypass` from 4.3 to 6.0
- [Commits](https://github.com/LSPosed/AndroidHiddenApiBypass/compare/v4.3...v6.0)

Updates `org.jetbrains.kotlin:kotlin-stdlib` from 2.1.0 to 2.1.10
- [Release notes](https://github.com/JetBrains/kotlin/releases)
- [Changelog](https://github.com/JetBrains/kotlin/blob/master/ChangeLog.md)
- [Commits](https://github.com/JetBrains/kotlin/compare/v2.1.0...v2.1.10)

Updates `org.jetbrains.kotlin.android` from 2.1.0 to 2.1.10
- [Release notes](https://github.com/JetBrains/kotlin/releases)
- [Changelog](https://github.com/JetBrains/kotlin/blob/master/ChangeLog.md)
- [Commits](https://github.com/JetBrains/kotlin/compare/v2.1.0...v2.1.10)

Updates `org.jetbrains.kotlin.android` from 2.1.0 to 2.1.10
- [Release notes](https://github.com/JetBrains/kotlin/releases)
- [Changelog](https://github.com/JetBrains/kotlin/blob/master/ChangeLog.md)
- [Commits](https://github.com/JetBrains/kotlin/compare/v2.1.0...v2.1.10)

Updates `androidx.navigation.safeargs` from 2.8.5 to 2.8.6

---
updated-dependencies:
- dependency-name: androidx.navigation:navigation-fragment dependency-type: direct:production update-type: version-update:semver-patch dependency-group: maven
- dependency-name: androidx.navigation:navigation-ui dependency-type: direct:production update-type: version-update:semver-patch dependency-group: maven
- dependency-name: androidx.navigation.safeargs dependency-type: direct:production update-type: version-update:semver-patch dependency-group: maven
- dependency-name: androidx.navigation:navigation-ui dependency-type: direct:production update-type: version-update:semver-patch dependency-group: maven
- dependency-name: com.google.code.gson:gson dependency-type: direct:production update-type: version-update:semver-minor dependency-group: maven
- dependency-name: org.lsposed.hiddenapibypass:hiddenapibypass dependency-type: direct:production update-type: version-update:semver-major dependency-group: maven
- dependency-name: org.jetbrains.kotlin:kotlin-stdlib dependency-type: direct:production update-type: version-update:semver-patch dependency-group: maven
- dependency-name: org.jetbrains.kotlin.android dependency-type: direct:production update-type: version-update:semver-patch dependency-group: maven
- dependency-name: org.jetbrains.kotlin.android dependency-type: direct:production update-type: version-update:semver-patch dependency-group: maven
- dependency-name: androidx.navigation.safeargs dependency-type: direct:production update-type: version-update:semver-patch dependency-group: maven ...