### PR TITLE
Add LoadedApk callers to deoptimize list

### DIFF
--- a/core/src/main/java/org/lsposed/lspd/deopt/InlinedMethodCallers.java
+++ b/core/src/main/java/org/lsposed/lspd/deopt/InlinedMethodCallers.java
@@ -20,6 +20,7 @@
 
 package org.lsposed.lspd.deopt;
 
+import android.app.Instrumentation;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.res.AssetManager;
@@ -57,6 +58,12 @@ public class InlinedMethodCallers {
             // callers of Application#attach(Context)
             {"android.app.Instrumentation", "newApplication", ClassLoader.class, String.class, Context.class},
             {"android.app.Instrumentation", "newApplication", ClassLoader.class, Context.class},
+
+            // callers of Instrumentation#newApplication(ClassLoader, String, Context)
+            {"android.app.LoadedApk", "makeApplicationInner", Boolean.TYPE, Instrumentation.class, Boolean.TYPE},
+            {"android.app.LoadedApk", "makeApplicationInner", Boolean.TYPE, Instrumentation.class},
+            {"android.app.LoadedApk", "makeApplication", Boolean.TYPE, Instrumentation.class},
+
             {"android.app.ContextImpl", "getSharedPreferencesPath", String.class}
     };
 


### PR DESCRIPTION
This commit attempts to resolve an issue reported by users on recent OnePlus software updates where LSPosed modules are no longer able to hook the `Application#attach` method.

The prevailing theory is that the Android Runtime (ART) on these devices has become more aggressive with method inlining. This optimization can cause the relatively small `Application#attach` method to be directly embedded into its calling methods, which makes it invisible to the hooking framework.

This approach is adapted from a reportedly successful commit in a community fork (LSPosed-Irena). It identifies `makeApplication` and `makeApplicationInner` within the `android.app.LoadedApk` class as the key callers to deoptimize. By adding these methods to the `BOOT_IMAGE` list, the goal is to prevent ART from inlining them, thus preserving `Application#attach` as a distinct and hookable method.