### PR TITLE
Update project references and polish content of docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 **A high-performance ART hooking framework for modern Android**
 
-[![Build](https://img.shields.io/github/actions/workflow/status/JingMatrix/LSPosed/core.yml?branch=master&event=push&logo=github&label=Build)](https://github.com/JingMatrix/LSPosed/actions/workflows/core.yml?query=event%3Apush+branch%3Amaster+is%3Acompleted)
+[![Build](https://img.shields.io/github/actions/workflow/status/JingMatrix/Vector/core.yml?branch=master&event=push&logo=github&label=Build)](https://github.com/JingMatrix/Vector/actions/workflows/core.yml?query=event%3Apush+branch%3Amaster+is%3Acompleted)
 [![Crowdin](https://img.shields.io/badge/Localization-Crowdin-blueviolet?logo=Crowdin)](https://crowdin.com/project/lsposed_jingmatrix)
-[![Download](https://img.shields.io/github/v/release/JingMatrix/LSPosed?color=orange&logoColor=orange&label=Download&logo=DocuSign)](https://github.com/JingMatrix/LSPosed/releases/latest)
-[![Total](https://shields.io/github/downloads/JingMatrix/LSPosed/total?logo=Bookmeter&label=Counts&logoColor=yellow&color=yellow)](https://github.com/JingMatrix/LSPosed/releases)
+[![Download](https://img.shields.io/github/v/release/JingMatrix/Vector?color=orange&logoColor=orange&label=Download&logo=DocuSign)](https://github.com/JingMatrix/Vector/releases/latest)
+[![Total](https://shields.io/github/downloads/JingMatrix/Vector/total?logo=Bookmeter&label=Counts&logoColor=yellow&color=yellow)](https://github.com/JingMatrix/Vector/releases)
 
 </div>
 
@@ -23,7 +23,7 @@ The framework allows modules to modify system and application behavior in-memory
 
 ### Compatibility
 
-Vector supports devices running **Android 8.1 through Android 17 Beta**. 
+Vector supports devices running **Android 8.1 through Android 17 Beta**.
 
 > [!TIP]
 > This framework requires a recent installation of Magisk or KernelSU with Zygisk enabled.
@@ -44,11 +44,18 @@ Vector supports devices running **Android 8.1 through Android 17 Beta**.
 
 | Channel | Source |
 | :--- | :--- |
-| Stable Releases | [GitHub Releases](https://github.com/JingMatrix/LSPosed/releases) |
-| Canary Builds | [GitHub Actions](https://github.com/JingMatrix/LSPosed/actions/workflows/core.yml?query=branch%3Amaster) |
+| **Stable Releases** | [GitHub Releases](https://github.com/JingMatrix/Vector/releases) |
+| **Canary (CI) Builds** | [GitHub Actions](https://github.com/JingMatrix/Vector/actions/workflows/core.yml?query=branch%3Amaster) |
 
 > [!NOTE]
-> Debug builds are recommended for users experiencing technical difficulties.
+> Debug builds are recommended for users encountering issues or performing troubleshooting.
+> We encourage users to test CI builds to help us identify bugs and accelerate development.
+
+> [!CAUTION]
+> GitHub requires users to be **logged in** to download CI artifacts.
+>
+> The link above is filtered to show only `master` branch builds.
+> Please note that builds from Pull Requests (PRs) are often unstable and potentially unsafe (depending on the authors); we recommend staying on the `master` branch for verified builds, unless you are asked to help our debugging sessions.
 
 ---
 
@@ -56,15 +63,16 @@ Vector supports devices running **Android 8.1 through Android 17 Beta**.
 
 If you encounter issues or wish to help improve the project, please refer to the resources below.
 
-*   **Troubleshooting:** Consult the [guide](https://github.com/JingMatrix/LSPosed/issues/123) before reporting bugs.
-*   **Discussions:** Join our community on [GitHub Discussions](https://github.com/JingMatrix/LSPosed/discussions).
+*   **Troubleshooting:** Consult the [guide](https://github.com/JingMatrix/Vector/issues/123) before reporting bugs.
+*   **Discussions:** Join our community on [GitHub Discussions](https://github.com/JingMatrix/Vector/discussions).
 *   **Localization:** Help translate the project via [Crowdin](https://crowdin.com/project/lsposed_jingmatrix).
 
 > [!IMPORTANT]
-> Bug reports are only accepted if they are based on the **latest debug build**. 
-> 
-> For Chinese speakers: 本项目只接受英语标题的 Issue。
-> 请使用[翻译工具](https://www.deepl.com/zh/translator)提交。
+> Bug reports are only accepted if they are based on the **latest debug build**.
+>
+> *Notice for Chinese speakers:*
+>
+> 为了提高沟通效率，本项目仅接受英文 Issue。请使用 [DeepL](https://www.deepl.com/zh/translator) 或其他翻译工具提交您的反馈。
 
 ---
 
@@ -75,6 +83,12 @@ Vector supports both legacy and modern hooking standards to ensure broad module 
 *   [Legacy Xposed API](https://api.xposed.info/)
 *   [Modern libxposed API](https://libxposed.github.io/api/)
 *   [Xposed Module Repository](https://github.com/Xposed-Modules-Repo)
+
+> [!NOTE]
+> Vector supports the `libxposed` API via two git submodules: the [module API](./xposed/libxposed) and the [service API](./services/libxposed).
+>
+> A successful GitHub Actions build of the [master](https://github.com/JingMatrix/Vector/tree/master) branch indicates that Vector fully supports these APIs at those specific commits.
+> Developers are suggested to check out the same commits as Vector.
 
 ---
 

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -79,7 +79,7 @@ When the wrapper executes, it connects to the daemon's abstract UNIX domain sock
 
 If the wrapper is disabled or incompatible, the daemon unmounts the binaries and utilizes `resetprop` to inject the inline flag directly into the `dalvik.vm.dex2oat-flags` system property as a fallback. The Kotlin daemon continuously monitors SELinux states via a `FileObserver` on `/sys/fs/selinux/enforce` and its policy files. It dynamically remounts the wrappers if the system drops to permissive mode or alters policy, ensuring the interception persists across state changes.
 
-### Native Logcat Telemetry
+### Native Logcat Monitoring
 Instead of relying on standard logcat shell execution, the daemon runs a native C++ process that interfaces directly with Android's `liblog` buffers (`LOG_ID_MAIN` and `LOG_ID_CRASH`). 
 
 The native parser performs zero-copy processing of log events, strictly filtering output by predefined exact tags (e.g., Magisk, KernelSU) and prefix tags (e.g., dex2oat, Vector, LSPosed). It writes the filtered output into two rotating log files: one for module frameworks and one for verbose system debugging, rotating them automatically when they reach 4MB.


### PR DESCRIPTION
- Migrate repository links from LSPosed to Vector.
- Add detailed guidelines for CI builds and `libxposed` submodule integration.
- Minor wording updates: `Telemetry` sounds potentially negative.