### PR TITLE
Fix Picocli ProGuard rules to prevent runtime crashes

### DIFF
--- a/daemon/proguard-rules.pro
+++ b/daemon/proguard-rules.pro
@@ -7,6 +7,19 @@
 -keepclasseswithmembers class org.matrix.vector.daemon.Cli {
     public static void main(java.lang.String[]);
 }
+-keep class org.matrix.vector.daemon.Cli { *; }
+-keep class org.matrix.vector.daemon.Cli$Companion { *; }
+-keep class org.matrix.vector.daemon.*Command { *; }
+-keep class org.matrix.vector.daemon.CliRequest { *; }
+-keep class org.matrix.vector.daemon.CliResponse { *; }
+
+-keep class picocli.CommandLine$AutoHelpMixin { *; }
+-keep class picocli.CommandLine$HelpCommand { *; }
+-keep @picocli.CommandLine$Command class picocli.** { *; }
+
+# MUST keep annotations for Picocli to function via reflection
+-keepattributes *Annotation*,Signature,InnerClasses,EnclosingMethod
+
 -keepclasseswithmembers class org.matrix.vector.daemon.env.LogcatMonitor {
     private int refreshFd(boolean);
 }

--- a/daemon/proguard-rules.pro
+++ b/daemon/proguard-rules.pro
@@ -7,18 +7,29 @@
 -keepclasseswithmembers class org.matrix.vector.daemon.Cli {
     public static void main(java.lang.String[]);
 }
--keep class org.matrix.vector.daemon.Cli { *; }
--keep class org.matrix.vector.daemon.Cli$Companion { *; }
--keep class org.matrix.vector.daemon.*Command { *; }
+
+
+# Keep IPC data models intact so Gson serializes the correct JSON keys
 -keep class org.matrix.vector.daemon.CliRequest { *; }
 -keep class org.matrix.vector.daemon.CliResponse { *; }
 
+# Preserve annotations, generic signatures, and inner classes (critical for picocli reflection)
+-keepattributes *Annotation*, Signature, InnerClasses, EnclosingMethod
+
+# Keep internal Picocli classes required for `mixinStandardHelpOptions = true`
 -keep class picocli.CommandLine$AutoHelpMixin { *; }
 -keep class picocli.CommandLine$HelpCommand { *; }
--keep @picocli.CommandLine$Command class picocli.** { *; }
 
-# MUST keep annotations for Picocli to function via reflection
--keepattributes *Annotation*,Signature,InnerClasses,EnclosingMethod
+# Keep ANY class (and its constructor) annotated with @Command
+-keep @picocli.CommandLine$Command class * {
+    <init>(...);
+}
+
+# Keep ANY field/method using a Picocli annotation (@Option, @Parameters, etc.)
+-keepclassmembers class * {
+    @picocli.CommandLine$* *;
+}
+
 
 -keepclasseswithmembers class org.matrix.vector.daemon.env.LogcatMonitor {
     private int refreshFd(boolean);


### PR DESCRIPTION
Updates the ProGuard configuration to explicitly keep reflection annotations, Kotlin companion objects, Picocli subcommands/help mixins, and IPC data classes that were being aggressively stripped by R8.

@JingMatrix When trying to use the command line interface in the release version, I get the following message.
> FATAL EXCEPTION: main (Show original)
                                                                                                    PID: 15311
                                                                                                    picocli.CommandLine$InitializationException: class xh is not a command: it has no @Command, @Option, @Parameters or @Unmatched annotations
                                                                                                    	at picocli.CommandLine$PicocliException.<init>(CommandLine.java:18581)
                                                                                                    	at picocli.CommandLine$InitializationException.<init>(CommandLine.java:18588)
                                                                                                    	at picocli.CommandLine$Model$CommandReflection.validateCommandSpec(CommandLine.java:12052)
                                                                                                    	at picocli.CommandLine$Model$CommandReflection.extractCommandSpec(CommandLine.java:11882)
                                                                                                    	at picocli.CommandLine$Model$CommandSpec.forAnnotatedObject(CommandLine.java:6396)
                                                                                                    	at picocli.CommandLine.<init>(CommandLine.java:230)
                                                                                                    	at picocli.CommandLine.toCommandLine(CommandLine.java:3639)
                                                                                                    	at picocli.CommandLine.access$16800(CommandLine.java:148)
                                                                                                    	at picocli.CommandLine$Model$CommandReflection.initSubcommands(CommandLine.java:11907)
                                                                                                    	at picocli.CommandLine$Model$CommandReflection.extractCommandSpec(CommandLine.java:11873)
                                                                                                    	at picocli.CommandLine$Model$CommandSpec.forAnnotatedObject(CommandLine.java:6396)
                                                                                                    	at picocli.CommandLine.<init>(CommandLine.java:230)
                                                                                                    	at picocli.CommandLine.<init>(CommandLine.java:224)
                                                                                                    	at picocli.CommandLine.<init>(CommandLine.java:199)
                                                                                                    	at org.matrix.vector.daemon.Cli$Companion.main(Cli.kt:230)
                                                                                                    	at org.matrix.vector.daemon.Cli.main(Cli.kt)
                                                                                                    	at com.android.internal.os.RuntimeInit.nativeFinishInit(Native Method)
                                                                                                    	at com.android.internal.os.RuntimeInit.main(RuntimeInit.java:470)