### PR TITLE
Fix module repository loading and missing README rendering

### DIFF
--- a/app/src/main/java/org/lsposed/manager/repo/RepoLoader.java
+++ b/app/src/main/java/org/lsposed/manager/repo/RepoLoader.java
@@ -76,11 +76,7 @@ public class RepoLoader {
     private final Path repoFile = Paths.get(App.getInstance().getFilesDir().getAbsolutePath(), "repo.json");
     private final Set<RepoListener> listeners = ConcurrentHashMap.newKeySet();
     private boolean repoLoaded = false;
-    private static final String originRepoUrl = "https://modules.lsposed.org/";
-    private static final String backupRepoUrl = "https://modules-blogcdn.lsposed.org/";
-
-    private static final String secondBackupRepoUrl = "https://modules-cloudflare.lsposed.org/";
-    private static String repoUrl = originRepoUrl;
+    private static final String repoUrl = "https://backup.modules.lsposed.org/";
     private final Resources resources = App.getInstance().getResources();
     private final String[] channels = resources.getStringArray(R.array.update_channel_values);
 
@@ -121,13 +117,6 @@ public class RepoLoader {
             Log.e(App.TAG, "load remote data", e);
             for (RepoListener listener : listeners) {
                 listener.onThrowable(e);
-            }
-            if (repoUrl.equals(originRepoUrl)) {
-                repoUrl = backupRepoUrl;
-                loadRemoteData();
-            } else if (repoUrl.equals(backupRepoUrl)) {
-                repoUrl = secondBackupRepoUrl;
-                loadRemoteData();
             }
         }
     }
@@ -252,16 +241,8 @@ public class RepoLoader {
             @Override
             public void onFailure(@NonNull Call call, @NonNull IOException e) {
                 Log.e(App.TAG, call.request().url() + e.getMessage());
-                if (repoUrl.equals(originRepoUrl)) {
-                    repoUrl = backupRepoUrl;
-                    loadRemoteReleases(packageName);
-                } else if (repoUrl.equals(backupRepoUrl)) {
-                    repoUrl = secondBackupRepoUrl;
-                    loadRemoteReleases(packageName);
-                } else {
-                    for (RepoListener listener : listeners) {
-                        listener.onThrowable(e);
-                    }
+                for (RepoListener listener : listeners) {
+                    listener.onThrowable(e);
                 }
             }
 

--- a/app/src/main/java/org/lsposed/manager/ui/fragment/RepoItemFragment.java
+++ b/app/src/main/java/org/lsposed/manager/ui/fragment/RepoItemFragment.java
@@ -184,7 +184,7 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
             } else {
                 direction = "ltr";
             }
-            if (text == null) {
+            if (TextUtils.isEmpty(text)) {
                 text = "<center>" + App.getInstance().getString(R.string.list_empty) + "</center>";
             }
             if (ResourceUtils.isNightMode(getResources().getConfiguration())) {
@@ -238,6 +238,27 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
         }
     }
 
+    @Nullable
+    private OnlineModule refreshModuleFromRepo() {
+        if (module == null || module.getName() == null) return module;
+        var updatedModule = RepoLoader.getInstance().getOnlineModule(module.getName());
+        if (updatedModule != null) {
+            module = updatedModule;
+        }
+        return module;
+    }
+
+    @Nullable
+    private String getModuleReadme() {
+        var currentModule = refreshModuleFromRepo();
+        if (currentModule == null) return null;
+        String readme = currentModule.getReadmeHTML();
+        if (TextUtils.isEmpty(readme)) {
+            readme = currentModule.getReadme();
+        }
+        return readme;
+    }
+
     @Override
     public void onCreateMenu(@NonNull Menu menu, @NonNull MenuInflater menuInflater) {
 
@@ -261,7 +282,16 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
     }
 
     @Override
+    public void onRepoLoaded() {
+        refreshModuleFromRepo();
+        if (releaseAdapter != null) {
+            runAsync(releaseAdapter::loadItems);
+        }
+    }
+
+    @Override
     public void onModuleReleasesLoaded(OnlineModule module) {
+        if (this.module == null || module == null || !TextUtils.equals(this.module.getName(), module.getName())) return;
         this.module = module;
         var repoLoader = RepoLoader.getInstance();
         if (releaseAdapter != null) {
@@ -611,8 +641,16 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
         }
     }
 
-    public static class ReadmeFragment extends BorderFragment {
+    public static class ReadmeFragment extends BorderFragment implements RepoLoader.RepoListener {
         ItemRepoReadmeBinding binding;
+
+        private void renderReadme() {
+            var parent = getParentFragment();
+            if (!(parent instanceof RepoItemFragment) || binding == null) return;
+
+            var repoItemFragment = (RepoItemFragment) parent;
+            repoItemFragment.renderGithubMarkdown(binding.readme, repoItemFragment.getModuleReadme());
+        }
 
         @Nullable
         @Override
@@ -624,11 +662,32 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
                 }
                 return null;
             }
-            var repoItemFragment = (RepoItemFragment) parent;
             binding = ItemRepoReadmeBinding.inflate(getLayoutInflater(), container, false);
-            repoItemFragment.renderGithubMarkdown(binding.readme, repoItemFragment.module.getReadmeHTML());
+            renderReadme();
             borderView = binding.scrollView;
+            RepoLoader.getInstance().addListener(this);
             return binding.getRoot();
+        }
+
+        @Override
+        public void onRepoLoaded() {
+            if (binding != null) {
+                runOnUiThread(this::renderReadme);
+            }
+        }
+
+        @Override
+        public void onModuleReleasesLoaded(OnlineModule module) {
+            if (binding != null) {
+                runOnUiThread(this::renderReadme);
+            }
+        }
+
+        @Override
+        public void onDestroyView() {
+            RepoLoader.getInstance().removeListener(this);
+            binding = null;
+            super.onDestroyView();
         }
 
         @Override

--- a/app/src/main/java/org/lsposed/manager/ui/fragment/RepoItemFragment.java
+++ b/app/src/main/java/org/lsposed/manager/ui/fragment/RepoItemFragment.java
@@ -109,6 +109,8 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
     OnlineModule module;
     private ReleaseAdapter releaseAdapter;
     private InformationAdapter informationAdapter;
+    private boolean remoteModuleLoadRequested = false;
+    private boolean releaseLoadRequestedByUser = false;
 
     @Nullable
     @Override
@@ -147,6 +149,7 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
         releaseAdapter = new ReleaseAdapter();
         informationAdapter = new InformationAdapter();
         RepoLoader.getInstance().addListener(this);
+        loadRemoteModuleIfReadmeMissing();
         return binding.getRoot();
     }
 
@@ -248,6 +251,19 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
         return module;
     }
 
+    private boolean hasReadme(@Nullable OnlineModule module) {
+        return module != null && (!TextUtils.isEmpty(module.getReadmeHTML()) || !TextUtils.isEmpty(module.getReadme()));
+    }
+
+    private void loadRemoteModuleIfReadmeMissing() {
+        var currentModule = refreshModuleFromRepo();
+        if (currentModule == null || currentModule.getName() == null) return;
+        if (remoteModuleLoadRequested || currentModule.releasesLoaded || hasReadme(currentModule)) return;
+
+        remoteModuleLoadRequested = true;
+        RepoLoader.getInstance().loadRemoteReleases(currentModule.getName());
+    }
+
     @Nullable
     private String getModuleReadme() {
         var currentModule = refreshModuleFromRepo();
@@ -255,6 +271,9 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
         String readme = currentModule.getReadmeHTML();
         if (TextUtils.isEmpty(readme)) {
             readme = currentModule.getReadme();
+        }
+        if (TextUtils.isEmpty(readme)) {
+            loadRemoteModuleIfReadmeMissing();
         }
         return readme;
     }
@@ -284,6 +303,7 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
     @Override
     public void onRepoLoaded() {
         refreshModuleFromRepo();
+        loadRemoteModuleIfReadmeMissing();
         if (releaseAdapter != null) {
             runAsync(releaseAdapter::loadItems);
         }
@@ -297,9 +317,10 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
         if (releaseAdapter != null) {
             runAsync(releaseAdapter::loadItems);
         }
-        if ((repoLoader.getReleases(module.getName()) != null ? repoLoader.getReleases(module.getName()).size() : 1) == 1) {
+        if (releaseLoadRequestedByUser && (repoLoader.getReleases(module.getName()) != null ? repoLoader.getReleases(module.getName()).size() : 1) == 1) {
             showHint(R.string.module_release_no_more, true);
         }
+        releaseLoadRequestedByUser = false;
     }
 
     @Override
@@ -486,6 +507,7 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
                     if (holder.progress.getVisibility() == View.GONE) {
                         holder.title.setVisibility(View.GONE);
                         holder.progress.show();
+                        releaseLoadRequestedByUser = true;
                         RepoLoader.getInstance().loadRemoteReleases(module.getName());
                     }
                 });

--- a/app/src/main/java/org/lsposed/manager/ui/fragment/RepoItemFragment.java
+++ b/app/src/main/java/org/lsposed/manager/ui/fragment/RepoItemFragment.java
@@ -701,7 +701,13 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
         @Override
         public void onModuleReleasesLoaded(OnlineModule module) {
             if (binding != null) {
-                runOnUiThread(this::renderReadme);
+                var parent = getParentFragment();
+                if (parent instanceof RepoItemFragment) {
+                    var repoItemFragment = (RepoItemFragment) parent;
+                    if (repoItemFragment.module != null && TextUtils.equals(repoItemFragment.module.getName(), module.getName())) {
+                        runOnUiThread(this::renderReadme);
+                    }
+                }
             }
         }
 

--- a/app/src/main/java/org/lsposed/manager/ui/fragment/RepoItemFragment.java
+++ b/app/src/main/java/org/lsposed/manager/ui/fragment/RepoItemFragment.java
@@ -287,7 +287,7 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
     public boolean onMenuItemSelected(@NonNull MenuItem item) {
         int id = item.getItemId();
         if (id == R.id.menu_open_in_browser) {
-            NavUtil.startURL(requireActivity(), "https://modules.lsposed.org/module/" + module.getName());
+            NavUtil.startURL(requireActivity(), "https://backup.modules.lsposed.org/module/" + module.getName());
             return true;
         }
         return false;


### PR DESCRIPTION
## Summary

Fix module repository loading by switching to the new official LSPosed backup CDN endpoint, `https://backup.modules.lsposed.org/`.

The previous repository endpoints and fallback mirrors are deprecated because the official LSPosed manager has moved to a newer CDN-backed repository request mechanism. The new official backup CDN endpoint remains compatible with the legacy repository API format used by this manager:

- `<base>/modules.json`
- `<base>/module/<package>.json`

This allows the existing repository loading logic to keep working without migrating this manager to the newer official request mechanism.

This PR also fixes README rendering on the module detail page. Some module entries from `modules.json` do not include full README content. When README content is missing, the manager now loads the per-module JSON and refreshes the README view after the full module data is available.

## Changes

- Switch module repository loading to the new official LSPosed backup CDN endpoint.
- Remove the deprecated old repository fallback chain.
- Load per-module JSON and refresh the README tab when README content is missing.