### PR TITLE
feat(repo): Updates backup routes and allows manual selection of warehouse sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,9 @@ If you encounter issues or wish to help improve the project, please refer to the
 > [!IMPORTANT]
 > Bug reports are only accepted if they are based on the **latest debug build**.
 >
-> *Notice for Chinese speakers:*
+> *致中文用户：*
 >
-> 为了提高沟通效率，本项目仅接受英文 Issue。请使用 [DeepL](https://www.deepl.com/zh/translator) 或其他翻译工具提交您的反馈。
-
+> 为保障问题沟通与处理效率，本项目仅受理英文 Issue。请使用 [DeepL](https://www.deepl.com/zh/translator) 或其他翻译工具如各种AI将反馈内容译为英文后提交。
 ---
 
 ### Developer Resources

--- a/app/src/main/java/org/lsposed/manager/repo/RepoLoader.java
+++ b/app/src/main/java/org/lsposed/manager/repo/RepoLoader.java
@@ -77,9 +77,7 @@ public class RepoLoader {
     private final Set<RepoListener> listeners = ConcurrentHashMap.newKeySet();
     private boolean repoLoaded = false;
     private static final String originRepoUrl = "https://modules.lsposed.org/";
-    private static final String backupRepoUrl = "https://modules-blogcdn.lsposed.org/";
-
-    private static final String secondBackupRepoUrl = "https://modules-cloudflare.lsposed.org/";
+    private static final String backupRepoUrl = "https://backup.modules.lsposed.org/";
     private static String repoUrl = originRepoUrl;
     private final Resources resources = App.getInstance().getResources();
     private final String[] channels = resources.getStringArray(R.array.update_channel_values);
@@ -124,9 +122,6 @@ public class RepoLoader {
             }
             if (repoUrl.equals(originRepoUrl)) {
                 repoUrl = backupRepoUrl;
-                loadRemoteData();
-            } else if (repoUrl.equals(backupRepoUrl)) {
-                repoUrl = secondBackupRepoUrl;
                 loadRemoteData();
             }
         }
@@ -254,9 +249,6 @@ public class RepoLoader {
                 Log.e(App.TAG, call.request().url() + e.getMessage());
                 if (repoUrl.equals(originRepoUrl)) {
                     repoUrl = backupRepoUrl;
-                    loadRemoteReleases(packageName);
-                } else if (repoUrl.equals(backupRepoUrl)) {
-                    repoUrl = secondBackupRepoUrl;
                     loadRemoteReleases(packageName);
                 } else {
                     for (RepoListener listener : listeners) {

--- a/app/src/main/java/org/lsposed/manager/repo/RepoLoader.java
+++ b/app/src/main/java/org/lsposed/manager/repo/RepoLoader.java
@@ -82,6 +82,11 @@ public class RepoLoader {
     private final Resources resources = App.getInstance().getResources();
     private final String[] channels = resources.getStringArray(R.array.update_channel_values);
 
+    private String getPreferredRepoUrl() {
+        var source = App.getPreferences().getString("repo_source", "SOURCE_ORIGIN");
+        return "SOURCE_BACKUP".equals(source) ? backupRepoUrl : originRepoUrl;
+    }
+
     public boolean isRepoLoaded() {
         return repoLoaded;
     }
@@ -95,6 +100,11 @@ public class RepoLoader {
     }
 
     synchronized public void loadRemoteData() {
+        loadRemoteData(getPreferredRepoUrl(), true);
+    }
+
+    synchronized private void loadRemoteData(String url, boolean allowFallback) {
+        repoUrl = url;
         repoLoaded = false;
         try {
             try (var response = App.getOkHttpClient().newCall(new Request.Builder().url(repoUrl + "modules.json").build()).execute()) {
@@ -120,9 +130,8 @@ public class RepoLoader {
             for (RepoListener listener : listeners) {
                 listener.onThrowable(e);
             }
-            if (repoUrl.equals(originRepoUrl)) {
-                repoUrl = backupRepoUrl;
-                loadRemoteData();
+            if (allowFallback) {
+                loadRemoteData(url.equals(originRepoUrl) ? backupRepoUrl : originRepoUrl, false);
             }
         }
     }
@@ -243,13 +252,18 @@ public class RepoLoader {
     }
 
     public void loadRemoteReleases(String packageName) {
-        App.getOkHttpClient().newCall(new Request.Builder().url(String.format(repoUrl + "module/%s.json", packageName)).build()).enqueue(new Callback() {
+        loadRemoteReleases(packageName, repoUrl, true);
+    }
+
+    private void loadRemoteReleases(String packageName, String url, boolean allowFallback) {
+        App.getOkHttpClient().newCall(new Request.Builder().url(String.format(url + "module/%s.json", packageName)).build()).enqueue(new Callback() {
             @Override
             public void onFailure(@NonNull Call call, @NonNull IOException e) {
                 Log.e(App.TAG, call.request().url() + e.getMessage());
-                if (repoUrl.equals(originRepoUrl)) {
-                    repoUrl = backupRepoUrl;
-                    loadRemoteReleases(packageName);
+                if (allowFallback) {
+                    String nextUrl = url.equals(originRepoUrl) ? backupRepoUrl : originRepoUrl;
+                    repoUrl = nextUrl;
+                    loadRemoteReleases(packageName, nextUrl, false);
                 } else {
                     for (RepoListener listener : listeners) {
                         listener.onThrowable(e);

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -202,6 +202,9 @@
     <string name="settings_enable_status_notification">إشعارات الحالة</string>
     <string name="settings_enable_status_notification_summary">إظهار إشعار يمكنه فتح مدير الطفيليات</string>
     <string name="settings_update_channel">قناة التحديث</string>
+    <string name="settings_repo_source">مصدر المستودع</string>
+    <string name="repo_source_origin">الافتراضي</string>
+    <string name="repo_source_backup">احتياطي</string>
     <string name="update_channel_stable">مستقر</string>
     <string name="update_channel_bate">تجريبي</string>
     <string name="update_channel_nightly">البناء الليلي</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -198,6 +198,9 @@
     <string name="settings_enable_status_notification">Notificación de estado</string>
     <string name="settings_enable_status_notification_summary">Mostrar una notificación que puede abrir el gestor de parásitos</string>
     <string name="settings_update_channel">Actualizar canal</string>
+    <string name="settings_repo_source">Fuente del repositorio</string>
+    <string name="repo_source_origin">Predeterminado</string>
+    <string name="repo_source_backup">Respaldo</string>
     <string name="update_channel_stable">Estable</string>
     <string name="update_channel_bate">Beta</string>
     <string name="update_channel_nightly">Construcción nocturna</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -200,6 +200,9 @@ JingMatrix</string>
     <string name="settings_enable_status_notification">Notification d\'état</string>
     <string name="settings_enable_status_notification_summary">Afficher une notification qui peut ouvrir le gestionnaire de parasites</string>
     <string name="settings_update_channel">Canal de mise à jour</string>
+    <string name="settings_repo_source">Source du dépôt</string>
+    <string name="repo_source_origin">Par défaut</string>
+    <string name="repo_source_backup">Secours</string>
     <string name="update_channel_stable">Stable</string>
     <string name="update_channel_bate">Bêta</string>
     <string name="update_channel_nightly">Alpha</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -202,6 +202,9 @@
     <string name="settings_enable_status_notification">Уведомление о состоянии</string>
     <string name="settings_enable_status_notification_summary">Показывать уведомление, через которое можно открыть parasitic-менеджер (т. е. LSPosed в скрытом режиме)</string>
     <string name="settings_update_channel">Канал обновлений</string>
+    <string name="settings_repo_source">Источник репозитория</string>
+    <string name="repo_source_origin">По умолчанию</string>
+    <string name="repo_source_backup">Резервный</string>
     <string name="update_channel_stable">Стабильные версии</string>
     <string name="update_channel_bate">Бета-версии</string>
     <string name="update_channel_nightly">Еженочные версии</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -197,6 +197,9 @@ JingMatrix</string>
     <string name="settings_enable_status_notification">状态通知</string>
     <string name="settings_enable_status_notification_summary">显示一个通知以打开寄生管理器</string>
     <string name="settings_update_channel">模块更新通道</string>
+    <string name="settings_repo_source">仓库来源</string>
+    <string name="repo_source_origin">默认</string>
+    <string name="repo_source_backup">备用</string>
     <string name="update_channel_stable">稳定版</string>
     <string name="update_channel_bate">测试版</string>
     <string name="update_channel_nightly">每夜版</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -196,6 +196,9 @@
     <string name="settings_enable_status_notification">狀態通知</string>
     <string name="settings_enable_status_notification_summary">顯示通知以便開啟寄生管理員</string>
     <string name="settings_update_channel">更新頻道</string>
+    <string name="settings_repo_source">倉庫來源</string>
+    <string name="repo_source_origin">預設</string>
+    <string name="repo_source_backup">備援</string>
     <string name="update_channel_stable">穩定版</string>
     <string name="update_channel_bate">測試版</string>
     <string name="update_channel_nightly">每夜構建</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -192,6 +192,9 @@
     <string name="settings_enable_status_notification">狀態通知</string>
     <string name="settings_enable_status_notification_summary">顯示通知以便開啟寄生管理員</string>
     <string name="settings_update_channel">更新通道</string>
+    <string name="settings_repo_source">倉庫來源</string>
+    <string name="repo_source_origin">預設</string>
+    <string name="repo_source_backup">備援</string>
     <string name="update_channel_stable">穩定版</string>
     <string name="update_channel_bate">測試版</string>
     <string name="update_channel_nightly">每夜構建</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -88,4 +88,14 @@
         <item>CHANNEL_NIGHTLY</item>
     </string-array>
 
+    <string-array name="repo_source_texts" translatable="false">
+        <item>@string/repo_source_origin</item>
+        <item>@string/repo_source_backup</item>
+    </string-array>
+
+    <string-array name="repo_source_values" translatable="false">
+        <item>SOURCE_ORIGIN</item>
+        <item>SOURCE_BACKUP</item>
+    </string-array>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,6 +198,9 @@
     <string name="settings_enable_status_notification">Status Notification</string>
     <string name="settings_enable_status_notification_summary">Show a notification that can open parasitic manager</string>
     <string name="settings_update_channel">Update channel</string>
+    <string name="settings_repo_source">Repository source</string>
+    <string name="repo_source_origin">Default</string>
+    <string name="repo_source_backup">Backup</string>
     <string name="update_channel_stable">Stable</string>
     <string name="update_channel_bate">Beta</string>
     <string name="update_channel_nightly">Nightly build</string>

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -116,6 +116,14 @@
             android:key="update_channel"
             android:summary="%s"
             android:title="@string/settings_update_channel" />
+        <rikka.preference.SimpleMenuPreference
+            android:defaultValue="SOURCE_ORIGIN"
+            android:entries="@array/repo_source_texts"
+            android:entryValues="@array/repo_source_values"
+            android:icon="@drawable/ic_outline_language_24"
+            android:key="repo_source"
+            android:summary="%s"
+            android:title="@string/settings_repo_source" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/settings_backup_and_restore">


### PR DESCRIPTION
Use backup.modules.lsposed.org as the backup repository. This is a temporary fix; the new version of the repository uses a different format, and the outdated backup connections have been removed.
Changes details:
1.
Backup lines have been updated:
The outdated backup addresses (blogcdn, cloudflare) have been removed. They have been replaced with backupmodules.lsposed.org.
The logic of reattempting operations has been simplified, making it more compatible with current warehouse architecture.
2.
Add the "Warehouse Source" option in "Settings > Warehouse".
Users are allowed to manually choose either “Default” or “Backup” route.
The automatic Fallback mechanism is retained: If the user attempts to connect to the preferred route but fails, the system will still automatically try to switch to another available route.