### PR TITLE
Fix module repository loading

### DIFF
--- a/app/src/main/assets/webview/markdown.css
+++ b/app/src/main/assets/webview/markdown.css
@@ -146,11 +146,13 @@ input[type="checkbox"] {
   color: var(--red-600);
 }
 
+/* GitHub now emits the heading permalink anchor as a sibling AFTER the
+   heading (not a child), so the old ".../h6 .octicon-link" hide rule no
+   longer matches it and the floated icon leaks into the left gutter of the
+   following block. These permalinks are useless in this viewer (no hover,
+   no address bar), so hide them outright. */
 .markdown-body .anchor {
-  float: left;
-  padding-right: 4px;
-  margin-left: -20px;
-  line-height: 1;
+  display: none;
 }
 
 .markdown-body .anchor:focus {

--- a/app/src/main/java/org/lsposed/manager/repo/RepoLoader.java
+++ b/app/src/main/java/org/lsposed/manager/repo/RepoLoader.java
@@ -106,6 +106,9 @@ public class RepoLoader {
                 }
                 try {
                     String bodyString = body.string();
+                    if (bodyString.trim().isEmpty()) {
+                        throw new IOException("Empty response from " + response.request().url());
+                    }
                     Files.write(repoFile, bodyString.getBytes(StandardCharsets.UTF_8));
                     loadLocalData(false);
                     loaded = true;
@@ -273,8 +276,14 @@ public class RepoLoader {
                     }
                     try {
                         String bodyString = body.string();
+                        if (bodyString.trim().isEmpty()) {
+                            throw new IOException("Empty response from " + call.request().url());
+                        }
                         Gson gson = new Gson();
                         OnlineModule module = gson.fromJson(bodyString, OnlineModule.class);
+                        if (module == null) {
+                            throw new IOException("Invalid response from " + call.request().url());
+                        }
                         module.releasesLoaded = true;
                         onlineModules.replace(packageName, module);
                         for (RepoListener listener : listeners) {

--- a/app/src/main/java/org/lsposed/manager/repo/RepoLoader.java
+++ b/app/src/main/java/org/lsposed/manager/repo/RepoLoader.java
@@ -76,11 +76,7 @@ public class RepoLoader {
     private final Path repoFile = Paths.get(App.getInstance().getFilesDir().getAbsolutePath(), "repo.json");
     private final Set<RepoListener> listeners = ConcurrentHashMap.newKeySet();
     private boolean repoLoaded = false;
-    private static final String originRepoUrl = "https://modules.lsposed.org/";
-    private static final String backupRepoUrl = "https://modules-blogcdn.lsposed.org/";
-
-    private static final String secondBackupRepoUrl = "https://modules-cloudflare.lsposed.org/";
-    private static String repoUrl = originRepoUrl;
+    private static final String repoUrl = "https://backup.modules.lsposed.org/";
     private final Resources resources = App.getInstance().getResources();
     private final String[] channels = resources.getStringArray(R.array.update_channel_values);
 
@@ -98,22 +94,25 @@ public class RepoLoader {
 
     synchronized public void loadRemoteData() {
         repoLoaded = false;
+        boolean loaded = false;
         try {
             try (var response = App.getOkHttpClient().newCall(new Request.Builder().url(repoUrl + "modules.json").build()).execute()) {
-
-                if (response.isSuccessful()) {
-                    ResponseBody body = response.body();
-                    if (body != null) {
-                        try {
-                            String bodyString = body.string();
-                            Files.write(repoFile, bodyString.getBytes(StandardCharsets.UTF_8));
-                            loadLocalData(false);
-                        } catch (Throwable t) {
-                            Log.e(App.TAG, Log.getStackTraceString(t));
-                            for (RepoListener listener : listeners) {
-                                listener.onThrowable(t);
-                            }
-                        }
+                if (!response.isSuccessful()) {
+                    throw new IOException("Unexpected response " + response.code() + " from " + response.request().url());
+                }
+                ResponseBody body = response.body();
+                if (body == null) {
+                    throw new IOException("Empty response from " + response.request().url());
+                }
+                try {
+                    String bodyString = body.string();
+                    Files.write(repoFile, bodyString.getBytes(StandardCharsets.UTF_8));
+                    loadLocalData(false);
+                    loaded = true;
+                } catch (Throwable t) {
+                    Log.e(App.TAG, Log.getStackTraceString(t));
+                    for (RepoListener listener : listeners) {
+                        listener.onThrowable(t);
                     }
                 }
             }
@@ -122,12 +121,12 @@ public class RepoLoader {
             for (RepoListener listener : listeners) {
                 listener.onThrowable(e);
             }
-            if (repoUrl.equals(originRepoUrl)) {
-                repoUrl = backupRepoUrl;
-                loadRemoteData();
-            } else if (repoUrl.equals(backupRepoUrl)) {
-                repoUrl = secondBackupRepoUrl;
-                loadRemoteData();
+        } finally {
+            if (!loaded) {
+                repoLoaded = true;
+                for (RepoListener listener : listeners) {
+                    listener.onRepoLoaded();
+                }
             }
         }
     }
@@ -252,39 +251,45 @@ public class RepoLoader {
             @Override
             public void onFailure(@NonNull Call call, @NonNull IOException e) {
                 Log.e(App.TAG, call.request().url() + e.getMessage());
-                if (repoUrl.equals(originRepoUrl)) {
-                    repoUrl = backupRepoUrl;
-                    loadRemoteReleases(packageName);
-                } else if (repoUrl.equals(backupRepoUrl)) {
-                    repoUrl = secondBackupRepoUrl;
-                    loadRemoteReleases(packageName);
-                } else {
-                    for (RepoListener listener : listeners) {
-                        listener.onThrowable(e);
-                    }
+                for (RepoListener listener : listeners) {
+                    listener.onThrowable(e);
                 }
             }
 
             @Override
             public void onResponse(@NonNull Call call, @NonNull Response response) {
-                if (response.isSuccessful()) {
+                if (!response.isSuccessful()) {
+                    var e = new IOException("Unexpected response " + response.code() + " from " + call.request().url());
+                    for (RepoListener listener : listeners) {
+                        listener.onThrowable(e);
+                    }
+                    response.close();
+                    return;
+                }
+                try (response) {
                     ResponseBody body = response.body();
-                    if (body != null) {
-                        try {
-                            String bodyString = body.string();
-                            Gson gson = new Gson();
-                            OnlineModule module = gson.fromJson(bodyString, OnlineModule.class);
-                            module.releasesLoaded = true;
-                            onlineModules.replace(packageName, module);
-                            for (RepoListener listener : listeners) {
-                                listener.onModuleReleasesLoaded(module);
-                            }
-                        } catch (Throwable t) {
-                            Log.e(App.TAG, Log.getStackTraceString(t));
-                            for (RepoListener listener : listeners) {
-                                listener.onThrowable(t);
-                            }
+                    if (body == null) {
+                        throw new IOException("Empty response from " + call.request().url());
+                    }
+                    try {
+                        String bodyString = body.string();
+                        Gson gson = new Gson();
+                        OnlineModule module = gson.fromJson(bodyString, OnlineModule.class);
+                        module.releasesLoaded = true;
+                        onlineModules.replace(packageName, module);
+                        for (RepoListener listener : listeners) {
+                            listener.onModuleReleasesLoaded(module);
                         }
+                    } catch (Throwable t) {
+                        Log.e(App.TAG, Log.getStackTraceString(t));
+                        for (RepoListener listener : listeners) {
+                            listener.onThrowable(t);
+                        }
+                    }
+                } catch (Throwable t) {
+                    Log.e(App.TAG, Log.getStackTraceString(t));
+                    for (RepoListener listener : listeners) {
+                        listener.onThrowable(t);
                     }
                 }
             }

--- a/app/src/main/java/org/lsposed/manager/repo/RepoLoader.java
+++ b/app/src/main/java/org/lsposed/manager/repo/RepoLoader.java
@@ -310,6 +310,7 @@ public class RepoLoader {
                     retryRemoteReleases(packageName, repoUrlIndex, attempts, e);
                     return;
                 }
+                OnlineModule module;
                 try (response) {
                     ResponseBody body = response.body();
                     if (body == null) {
@@ -320,19 +321,20 @@ public class RepoLoader {
                         throw new IOException("Empty response from " + call.request().url());
                     }
                     Gson gson = new Gson();
-                    OnlineModule module = gson.fromJson(bodyString, OnlineModule.class);
+                    module = gson.fromJson(bodyString, OnlineModule.class);
                     if (module == null) {
                         throw new IOException("Invalid response from " + call.request().url());
                     }
                     module.releasesLoaded = true;
                     onlineModules.replace(packageName, module);
                     repoUrl = candidateRepoUrl;
-                    for (RepoListener listener : listeners) {
-                        listener.onModuleReleasesLoaded(module);
-                    }
                 } catch (Throwable t) {
                     Log.e(App.TAG, Log.getStackTraceString(t));
                     retryRemoteReleases(packageName, repoUrlIndex, attempts, t);
+                    return;
+                }
+                for (RepoListener listener : listeners) {
+                    listener.onModuleReleasesLoaded(module);
                 }
             }
         });

--- a/app/src/main/java/org/lsposed/manager/repo/RepoLoader.java
+++ b/app/src/main/java/org/lsposed/manager/repo/RepoLoader.java
@@ -145,8 +145,8 @@ public class RepoLoader {
         Map<String, OnlineModule> modules = new HashMap<>();
         Arrays.stream(repoModules).forEach(onlineModule -> modules.put(onlineModule.getName(), onlineModule));
         var channel = App.getPreferences().getString("update_channel", channels[0]);
-        updateLatestVersion(repoModules, channel);
         onlineModules = modules;
+        updateLatestVersion(repoModules, channel);
     }
 
     private String requestString(String url) throws IOException {

--- a/app/src/main/java/org/lsposed/manager/repo/RepoLoader.java
+++ b/app/src/main/java/org/lsposed/manager/repo/RepoLoader.java
@@ -76,7 +76,13 @@ public class RepoLoader {
     private final Path repoFile = Paths.get(App.getInstance().getFilesDir().getAbsolutePath(), "repo.json");
     private final Set<RepoListener> listeners = ConcurrentHashMap.newKeySet();
     private boolean repoLoaded = false;
-    private static final String repoUrl = "https://backup.modules.lsposed.org/";
+    private static final String[] repoUrls = new String[]{
+            "https://backup.modules.lsposed.org/",
+            "https://modules.lsposed.org/",
+            "https://modules-blogcdn.lsposed.org/",
+            "https://modules-cloudflare.lsposed.org/"
+    };
+    private static String repoUrl = repoUrls[0];
     private final Resources resources = App.getInstance().getResources();
     private final String[] channels = resources.getStringArray(R.array.update_channel_values);
 
@@ -95,34 +101,25 @@ public class RepoLoader {
     synchronized public void loadRemoteData() {
         repoLoaded = false;
         boolean loaded = false;
+        Throwable lastError = null;
         try {
-            try (var response = App.getOkHttpClient().newCall(new Request.Builder().url(repoUrl + "modules.json").build()).execute()) {
-                if (!response.isSuccessful()) {
-                    throw new IOException("Unexpected response " + response.code() + " from " + response.request().url());
-                }
-                ResponseBody body = response.body();
-                if (body == null) {
-                    throw new IOException("Empty response from " + response.request().url());
-                }
+            for (String candidateRepoUrl : repoUrls) {
                 try {
-                    String bodyString = body.string();
-                    if (bodyString.trim().isEmpty()) {
-                        throw new IOException("Empty response from " + response.request().url());
-                    }
+                    String bodyString = requestString(candidateRepoUrl + "modules.json");
                     Files.write(repoFile, bodyString.getBytes(StandardCharsets.UTF_8));
+                    repoUrl = candidateRepoUrl;
                     loadLocalData(false);
                     loaded = true;
+                    break;
                 } catch (Throwable t) {
-                    Log.e(App.TAG, Log.getStackTraceString(t));
-                    for (RepoListener listener : listeners) {
-                        listener.onThrowable(t);
-                    }
+                    lastError = t;
+                    Log.e(App.TAG, "load remote data from " + candidateRepoUrl, t);
                 }
             }
-        } catch (Throwable e) {
-            Log.e(App.TAG, "load remote data", e);
-            for (RepoListener listener : listeners) {
-                listener.onThrowable(e);
+            if (!loaded && lastError != null) {
+                for (RepoListener listener : listeners) {
+                    listener.onThrowable(lastError);
+                }
             }
         } finally {
             if (!loaded) {
@@ -131,6 +128,23 @@ public class RepoLoader {
                     listener.onRepoLoaded();
                 }
             }
+        }
+    }
+
+    private String requestString(String url) throws IOException {
+        try (var response = App.getOkHttpClient().newCall(new Request.Builder().url(url).build()).execute()) {
+            if (!response.isSuccessful()) {
+                throw new IOException("Unexpected response " + response.code() + " from " + response.request().url());
+            }
+            ResponseBody body = response.body();
+            if (body == null) {
+                throw new IOException("Empty response from " + response.request().url());
+            }
+            String bodyString = body.string();
+            if (bodyString.trim().isEmpty()) {
+                throw new IOException("Empty response from " + response.request().url());
+            }
+            return bodyString;
         }
     }
 
@@ -250,23 +264,24 @@ public class RepoLoader {
     }
 
     public void loadRemoteReleases(String packageName) {
-        App.getOkHttpClient().newCall(new Request.Builder().url(String.format(repoUrl + "module/%s.json", packageName)).build()).enqueue(new Callback() {
+        loadRemoteReleases(packageName, 0);
+    }
+
+    private void loadRemoteReleases(String packageName, int repoUrlIndex) {
+        String candidateRepoUrl = repoUrls[repoUrlIndex];
+        App.getOkHttpClient().newCall(new Request.Builder().url(String.format(candidateRepoUrl + "module/%s.json", packageName)).build()).enqueue(new Callback() {
             @Override
             public void onFailure(@NonNull Call call, @NonNull IOException e) {
                 Log.e(App.TAG, call.request().url() + e.getMessage());
-                for (RepoListener listener : listeners) {
-                    listener.onThrowable(e);
-                }
+                retryRemoteReleases(packageName, repoUrlIndex, e);
             }
 
             @Override
             public void onResponse(@NonNull Call call, @NonNull Response response) {
                 if (!response.isSuccessful()) {
                     var e = new IOException("Unexpected response " + response.code() + " from " + call.request().url());
-                    for (RepoListener listener : listeners) {
-                        listener.onThrowable(e);
-                    }
                     response.close();
+                    retryRemoteReleases(packageName, repoUrlIndex, e);
                     return;
                 }
                 try (response) {
@@ -286,6 +301,7 @@ public class RepoLoader {
                         }
                         module.releasesLoaded = true;
                         onlineModules.replace(packageName, module);
+                        repoUrl = candidateRepoUrl;
                         for (RepoListener listener : listeners) {
                             listener.onModuleReleasesLoaded(module);
                         }
@@ -303,6 +319,16 @@ public class RepoLoader {
                 }
             }
         });
+    }
+
+    private void retryRemoteReleases(String packageName, int repoUrlIndex, Throwable error) {
+        if (repoUrlIndex + 1 < repoUrls.length) {
+            loadRemoteReleases(packageName, repoUrlIndex + 1);
+        } else {
+            for (RepoListener listener : listeners) {
+                listener.onThrowable(error);
+            }
+        }
     }
 
     public void addListener(RepoListener listener) {

--- a/app/src/main/java/org/lsposed/manager/repo/RepoLoader.java
+++ b/app/src/main/java/org/lsposed/manager/repo/RepoLoader.java
@@ -289,33 +289,24 @@ public class RepoLoader {
                     if (body == null) {
                         throw new IOException("Empty response from " + call.request().url());
                     }
-                    try {
-                        String bodyString = body.string();
-                        if (bodyString.trim().isEmpty()) {
-                            throw new IOException("Empty response from " + call.request().url());
-                        }
-                        Gson gson = new Gson();
-                        OnlineModule module = gson.fromJson(bodyString, OnlineModule.class);
-                        if (module == null) {
-                            throw new IOException("Invalid response from " + call.request().url());
-                        }
-                        module.releasesLoaded = true;
-                        onlineModules.replace(packageName, module);
-                        repoUrl = candidateRepoUrl;
-                        for (RepoListener listener : listeners) {
-                            listener.onModuleReleasesLoaded(module);
-                        }
-                    } catch (Throwable t) {
-                        Log.e(App.TAG, Log.getStackTraceString(t));
-                        for (RepoListener listener : listeners) {
-                            listener.onThrowable(t);
-                        }
+                    String bodyString = body.string();
+                    if (bodyString.trim().isEmpty()) {
+                        throw new IOException("Empty response from " + call.request().url());
+                    }
+                    Gson gson = new Gson();
+                    OnlineModule module = gson.fromJson(bodyString, OnlineModule.class);
+                    if (module == null) {
+                        throw new IOException("Invalid response from " + call.request().url());
+                    }
+                    module.releasesLoaded = true;
+                    onlineModules.replace(packageName, module);
+                    repoUrl = candidateRepoUrl;
+                    for (RepoListener listener : listeners) {
+                        listener.onModuleReleasesLoaded(module);
                     }
                 } catch (Throwable t) {
                     Log.e(App.TAG, Log.getStackTraceString(t));
-                    for (RepoListener listener : listeners) {
-                        listener.onThrowable(t);
-                    }
+                    retryRemoteReleases(packageName, repoUrlIndex, t);
                 }
             }
         });

--- a/app/src/main/java/org/lsposed/manager/repo/RepoLoader.java
+++ b/app/src/main/java/org/lsposed/manager/repo/RepoLoader.java
@@ -115,6 +115,7 @@ public class RepoLoader {
                     String bodyString = requestString(candidateRepoUrl + "modules.json");
                     OnlineModule[] repoModules = parseRepoModules(bodyString);
                     Files.write(repoFile, bodyString.getBytes(StandardCharsets.UTF_8));
+                    Log.i(App.TAG, "repo: fetched module list from " + candidateRepoUrl + " (" + repoModules.length + " entries, " + bodyString.length() + " bytes)");
                     replaceRepoModules(repoModules);
                     loaded = true;
                     break;
@@ -130,6 +131,7 @@ public class RepoLoader {
             }
         } finally {
             if (!loaded) {
+                Log.w(App.TAG, "repo: module list load failed on all mirrors, keeping cached data (" + onlineModules.size() + " modules)");
                 repoLoaded = true;
                 for (RepoListener listener : listeners) {
                     listener.onRepoLoaded();
@@ -152,6 +154,7 @@ public class RepoLoader {
         Arrays.stream(repoModules).forEach(onlineModule -> modules.put(onlineModule.getName(), onlineModule));
         var channel = App.getPreferences().getString("update_channel", channels[0]);
         onlineModules = modules;
+        Log.i(App.TAG, "repo: onlineModules replaced, now " + modules.size() + " modules (channel=" + channel + ")");
         updateLatestVersion(repoModules, channel);
     }
 
@@ -174,6 +177,7 @@ public class RepoLoader {
 
     synchronized public void loadLocalData(boolean updateRemoteRepo) {
         repoLoaded = false;
+        Log.i(App.TAG, "repo: loadLocalData(updateRemoteRepo=" + updateRemoteRepo + "), cacheExists=" + Files.exists(repoFile));
         try {
             if (Files.notExists(repoFile)) {
                 loadRemoteData();
@@ -182,9 +186,10 @@ public class RepoLoader {
             byte[] encoded = Files.readAllBytes(repoFile);
             String bodyString = new String(encoded, StandardCharsets.UTF_8);
             OnlineModule[] repoModules = parseRepoModules(bodyString);
+            Log.i(App.TAG, "repo: loadLocalData parsed " + repoModules.length + " modules from cache (" + encoded.length + " bytes)");
             replaceRepoModules(repoModules);
         } catch (Throwable t) {
-            Log.e(App.TAG, Log.getStackTraceString(t));
+            Log.e(App.TAG, "repo: loadLocalData failed", t);
             for (RepoListener listener : listeners) {
                 listener.onThrowable(t);
             }
@@ -290,21 +295,23 @@ public class RepoLoader {
         if (attempt >= detailRepoUrls.length) {
             // Every detail mirror failed; fall back to the module's GitHub repo
             // so we can at least recover the README instead of failing outright.
+            Log.w(App.TAG, "repo: detail mirrors exhausted for " + packageName + ", falling back to GitHub README");
             loadReadmeFromGithub(packageName, null, new IOException("All module detail mirrors failed for " + packageName));
             return;
         }
         String candidateRepoUrl = detailRepoUrls[attempt];
+        Log.i(App.TAG, "repo: loadRemoteReleases " + packageName + " attempt " + attempt + " -> " + candidateRepoUrl);
         App.getOkHttpClient().newCall(new Request.Builder().url(String.format(candidateRepoUrl + "module/%s.json", packageName)).build()).enqueue(new Callback() {
             @Override
             public void onFailure(@NonNull Call call, @NonNull IOException e) {
-                Log.e(App.TAG, call.request().url() + e.getMessage());
+                Log.w(App.TAG, "repo: detail fetch failed for " + packageName + " from " + call.request().url() + ": " + e.getMessage());
                 loadRemoteReleases(packageName, attempt + 1);
             }
 
             @Override
             public void onResponse(@NonNull Call call, @NonNull Response response) {
                 if (!response.isSuccessful()) {
-                    Log.e(App.TAG, "Unexpected response " + response.code() + " from " + call.request().url());
+                    Log.w(App.TAG, "repo: detail unexpected response " + response.code() + " for " + packageName + " from " + call.request().url());
                     response.close();
                     loadRemoteReleases(packageName, attempt + 1);
                     return;
@@ -327,10 +334,12 @@ public class RepoLoader {
                     module.releasesLoaded = true;
                     onlineModules.replace(packageName, module);
                 } catch (Throwable t) {
-                    Log.e(App.TAG, Log.getStackTraceString(t));
+                    Log.e(App.TAG, "repo: detail parse failed for " + packageName, t);
                     loadRemoteReleases(packageName, attempt + 1);
                     return;
                 }
+                int releaseCount = module.getReleases() == null ? 0 : module.getReleases().size();
+                Log.i(App.TAG, "repo: detail loaded for " + packageName + " from " + candidateRepoUrl + ", hasReadme=" + hasReadme(module) + ", releases=" + releaseCount);
                 if (hasReadme(module)) {
                     for (RepoListener listener : listeners) {
                         listener.onModuleReleasesLoaded(module);
@@ -338,6 +347,7 @@ public class RepoLoader {
                 } else {
                     // Detail loaded but carries no README; enrich it from GitHub
                     // before publishing so the README tab is not shown as empty.
+                    Log.i(App.TAG, "repo: " + packageName + " detail has no README, fetching from GitHub");
                     loadReadmeFromGithub(packageName, module, null);
                 }
             }
@@ -357,6 +367,7 @@ public class RepoLoader {
     private void loadReadmeFromGithub(String packageName, @Nullable OnlineModule loaded, @Nullable Throwable error) {
         OnlineModule target = loaded != null ? loaded : onlineModules.get(packageName);
         if (target == null) {
+            Log.w(App.TAG, "repo: no cached module to enrich for " + packageName + ", giving up");
             if (error != null) {
                 for (RepoListener listener : listeners) {
                     listener.onThrowable(error);
@@ -370,7 +381,7 @@ public class RepoLoader {
                 .build()).enqueue(new Callback() {
             @Override
             public void onFailure(@NonNull Call call, @NonNull IOException e) {
-                Log.e(App.TAG, call.request().url() + e.getMessage());
+                Log.w(App.TAG, "repo: GitHub README fetch failed for " + packageName + ": " + e.getMessage());
                 publishReadmeFallback(packageName, target, null, loaded != null, error);
             }
 
@@ -387,11 +398,12 @@ public class RepoLoader {
                             }
                         }
                     } else {
-                        Log.e(App.TAG, "Unexpected response " + response.code() + " from " + call.request().url());
+                        Log.w(App.TAG, "repo: GitHub README unexpected response " + response.code() + " for " + packageName);
                     }
                 } catch (Throwable t) {
-                    Log.e(App.TAG, Log.getStackTraceString(t));
+                    Log.e(App.TAG, "repo: GitHub README read failed for " + packageName, t);
                 }
+                Log.i(App.TAG, "repo: GitHub README for " + packageName + " -> " + (html != null ? "recovered (" + html.length() + " bytes)" : "unavailable"));
                 publishReadmeFallback(packageName, target, html, loaded != null, error);
             }
         });
@@ -405,10 +417,12 @@ public class RepoLoader {
         if (detailLoaded || readmeHTML != null) {
             // The releases are already valid, or we recovered a README: publish
             // the (possibly enriched) module to the UI.
+            Log.i(App.TAG, "repo: publishing " + packageName + " (detailLoaded=" + detailLoaded + ", readmeRecovered=" + (readmeHTML != null) + ")");
             for (RepoListener listener : listeners) {
                 listener.onModuleReleasesLoaded(module);
             }
         } else if (error != null) {
+            Log.w(App.TAG, "repo: nothing to publish for " + packageName + ", reporting failure");
             for (RepoListener listener : listeners) {
                 listener.onThrowable(error);
             }

--- a/app/src/main/java/org/lsposed/manager/repo/RepoLoader.java
+++ b/app/src/main/java/org/lsposed/manager/repo/RepoLoader.java
@@ -106,9 +106,10 @@ public class RepoLoader {
             for (String candidateRepoUrl : repoUrls) {
                 try {
                     String bodyString = requestString(candidateRepoUrl + "modules.json");
+                    OnlineModule[] repoModules = parseRepoModules(bodyString);
                     Files.write(repoFile, bodyString.getBytes(StandardCharsets.UTF_8));
                     repoUrl = candidateRepoUrl;
-                    loadLocalData(false);
+                    replaceRepoModules(repoModules);
                     loaded = true;
                     break;
                 } catch (Throwable t) {
@@ -129,6 +130,23 @@ public class RepoLoader {
                 }
             }
         }
+    }
+
+    private OnlineModule[] parseRepoModules(String bodyString) throws IOException {
+        Gson gson = new Gson();
+        OnlineModule[] repoModules = gson.fromJson(bodyString, OnlineModule[].class);
+        if (repoModules == null) {
+            throw new IOException("Invalid repo response");
+        }
+        return repoModules;
+    }
+
+    private void replaceRepoModules(OnlineModule[] repoModules) {
+        Map<String, OnlineModule> modules = new HashMap<>();
+        Arrays.stream(repoModules).forEach(onlineModule -> modules.put(onlineModule.getName(), onlineModule));
+        var channel = App.getPreferences().getString("update_channel", channels[0]);
+        updateLatestVersion(repoModules, channel);
+        onlineModules = modules;
     }
 
     private String requestString(String url) throws IOException {
@@ -157,13 +175,8 @@ public class RepoLoader {
             }
             byte[] encoded = Files.readAllBytes(repoFile);
             String bodyString = new String(encoded, StandardCharsets.UTF_8);
-            Gson gson = new Gson();
-            Map<String, OnlineModule> modules = new HashMap<>();
-            OnlineModule[] repoModules = gson.fromJson(bodyString, OnlineModule[].class);
-            Arrays.stream(repoModules).forEach(onlineModule -> modules.put(onlineModule.getName(), onlineModule));
-            var channel = App.getPreferences().getString("update_channel", channels[0]);
-            updateLatestVersion(repoModules, channel);
-            onlineModules = modules;
+            OnlineModule[] repoModules = parseRepoModules(bodyString);
+            replaceRepoModules(repoModules);
         } catch (Throwable t) {
             Log.e(App.TAG, Log.getStackTraceString(t));
             for (RepoListener listener : listeners) {
@@ -264,16 +277,29 @@ public class RepoLoader {
     }
 
     public void loadRemoteReleases(String packageName) {
-        loadRemoteReleases(packageName, 0);
+        loadRemoteReleases(packageName, repoUrlIndex(repoUrl), 0);
     }
 
-    private void loadRemoteReleases(String packageName, int repoUrlIndex) {
+    private int repoUrlIndex(String url) {
+        for (int i = 0; i < repoUrls.length; i++) {
+            if (repoUrls[i].equals(url)) {
+                return i;
+            }
+        }
+        return 0;
+    }
+
+    private int nextRepoUrlIndex(int repoUrlIndex) {
+        return (repoUrlIndex + 1) % repoUrls.length;
+    }
+
+    private void loadRemoteReleases(String packageName, int repoUrlIndex, int attempts) {
         String candidateRepoUrl = repoUrls[repoUrlIndex];
         App.getOkHttpClient().newCall(new Request.Builder().url(String.format(candidateRepoUrl + "module/%s.json", packageName)).build()).enqueue(new Callback() {
             @Override
             public void onFailure(@NonNull Call call, @NonNull IOException e) {
                 Log.e(App.TAG, call.request().url() + e.getMessage());
-                retryRemoteReleases(packageName, repoUrlIndex, e);
+                retryRemoteReleases(packageName, repoUrlIndex, attempts, e);
             }
 
             @Override
@@ -281,7 +307,7 @@ public class RepoLoader {
                 if (!response.isSuccessful()) {
                     var e = new IOException("Unexpected response " + response.code() + " from " + call.request().url());
                     response.close();
-                    retryRemoteReleases(packageName, repoUrlIndex, e);
+                    retryRemoteReleases(packageName, repoUrlIndex, attempts, e);
                     return;
                 }
                 try (response) {
@@ -306,15 +332,15 @@ public class RepoLoader {
                     }
                 } catch (Throwable t) {
                     Log.e(App.TAG, Log.getStackTraceString(t));
-                    retryRemoteReleases(packageName, repoUrlIndex, t);
+                    retryRemoteReleases(packageName, repoUrlIndex, attempts, t);
                 }
             }
         });
     }
 
-    private void retryRemoteReleases(String packageName, int repoUrlIndex, Throwable error) {
-        if (repoUrlIndex + 1 < repoUrls.length) {
-            loadRemoteReleases(packageName, repoUrlIndex + 1);
+    private void retryRemoteReleases(String packageName, int repoUrlIndex, int attempts, Throwable error) {
+        if (attempts + 1 < repoUrls.length) {
+            loadRemoteReleases(packageName, nextRepoUrlIndex(repoUrlIndex), attempts + 1);
         } else {
             for (RepoListener listener : listeners) {
                 listener.onThrowable(error);

--- a/app/src/main/java/org/lsposed/manager/repo/RepoLoader.java
+++ b/app/src/main/java/org/lsposed/manager/repo/RepoLoader.java
@@ -76,13 +76,20 @@ public class RepoLoader {
     private final Path repoFile = Paths.get(App.getInstance().getFilesDir().getAbsolutePath(), "repo.json");
     private final Set<RepoListener> listeners = ConcurrentHashMap.newKeySet();
     private boolean repoLoaded = false;
-    private static final String[] repoUrls = new String[]{
-            "https://backup.modules.lsposed.org/",
-            "https://modules.lsposed.org/",
-            "https://modules-blogcdn.lsposed.org/",
-            "https://modules-cloudflare.lsposed.org/"
+    // The full module list is only served by the backup host; modules.lsposed.org
+    // returns 403 for modules.json, and the blogcdn/cloudflare mirrors are dead.
+    private static final String[] listRepoUrls = new String[]{
+            "https://backup.modules.lsposed.org/"
     };
-    private static String repoUrl = repoUrls[0];
+    // Per-module detail JSON is served by both the backup host and the public
+    // site, so the latter acts as a real fallback for module/<package>.json.
+    private static final String[] detailRepoUrls = new String[]{
+            "https://backup.modules.lsposed.org/",
+            "https://modules.lsposed.org/"
+    };
+    // Each module is mirrored as a GitHub repo under this org; used as a
+    // last-resort README source when the JSON API omits it or is unreachable.
+    private static final String moduleGithubReadmeUrl = "https://api.github.com/repos/Xposed-Modules-Repo/%s/readme";
     private final Resources resources = App.getInstance().getResources();
     private final String[] channels = resources.getStringArray(R.array.update_channel_values);
 
@@ -103,12 +110,11 @@ public class RepoLoader {
         boolean loaded = false;
         Throwable lastError = null;
         try {
-            for (String candidateRepoUrl : repoUrls) {
+            for (String candidateRepoUrl : listRepoUrls) {
                 try {
                     String bodyString = requestString(candidateRepoUrl + "modules.json");
                     OnlineModule[] repoModules = parseRepoModules(bodyString);
                     Files.write(repoFile, bodyString.getBytes(StandardCharsets.UTF_8));
-                    repoUrl = candidateRepoUrl;
                     replaceRepoModules(repoModules);
                     loaded = true;
                     break;
@@ -277,37 +283,30 @@ public class RepoLoader {
     }
 
     public void loadRemoteReleases(String packageName) {
-        loadRemoteReleases(packageName, repoUrlIndex(repoUrl), 0);
+        loadRemoteReleases(packageName, 0);
     }
 
-    private int repoUrlIndex(String url) {
-        for (int i = 0; i < repoUrls.length; i++) {
-            if (repoUrls[i].equals(url)) {
-                return i;
-            }
+    private void loadRemoteReleases(String packageName, int attempt) {
+        if (attempt >= detailRepoUrls.length) {
+            // Every detail mirror failed; fall back to the module's GitHub repo
+            // so we can at least recover the README instead of failing outright.
+            loadReadmeFromGithub(packageName, null, new IOException("All module detail mirrors failed for " + packageName));
+            return;
         }
-        return 0;
-    }
-
-    private int nextRepoUrlIndex(int repoUrlIndex) {
-        return (repoUrlIndex + 1) % repoUrls.length;
-    }
-
-    private void loadRemoteReleases(String packageName, int repoUrlIndex, int attempts) {
-        String candidateRepoUrl = repoUrls[repoUrlIndex];
+        String candidateRepoUrl = detailRepoUrls[attempt];
         App.getOkHttpClient().newCall(new Request.Builder().url(String.format(candidateRepoUrl + "module/%s.json", packageName)).build()).enqueue(new Callback() {
             @Override
             public void onFailure(@NonNull Call call, @NonNull IOException e) {
                 Log.e(App.TAG, call.request().url() + e.getMessage());
-                retryRemoteReleases(packageName, repoUrlIndex, attempts, e);
+                loadRemoteReleases(packageName, attempt + 1);
             }
 
             @Override
             public void onResponse(@NonNull Call call, @NonNull Response response) {
                 if (!response.isSuccessful()) {
-                    var e = new IOException("Unexpected response " + response.code() + " from " + call.request().url());
+                    Log.e(App.TAG, "Unexpected response " + response.code() + " from " + call.request().url());
                     response.close();
-                    retryRemoteReleases(packageName, repoUrlIndex, attempts, e);
+                    loadRemoteReleases(packageName, attempt + 1);
                     return;
                 }
                 OnlineModule module;
@@ -327,23 +326,89 @@ public class RepoLoader {
                     }
                     module.releasesLoaded = true;
                     onlineModules.replace(packageName, module);
-                    repoUrl = candidateRepoUrl;
                 } catch (Throwable t) {
                     Log.e(App.TAG, Log.getStackTraceString(t));
-                    retryRemoteReleases(packageName, repoUrlIndex, attempts, t);
+                    loadRemoteReleases(packageName, attempt + 1);
                     return;
                 }
-                for (RepoListener listener : listeners) {
-                    listener.onModuleReleasesLoaded(module);
+                if (hasReadme(module)) {
+                    for (RepoListener listener : listeners) {
+                        listener.onModuleReleasesLoaded(module);
+                    }
+                } else {
+                    // Detail loaded but carries no README; enrich it from GitHub
+                    // before publishing so the README tab is not shown as empty.
+                    loadReadmeFromGithub(packageName, module, null);
                 }
             }
         });
     }
 
-    private void retryRemoteReleases(String packageName, int repoUrlIndex, int attempts, Throwable error) {
-        if (attempts + 1 < repoUrls.length) {
-            loadRemoteReleases(packageName, nextRepoUrlIndex(repoUrlIndex), attempts + 1);
-        } else {
+    private boolean hasReadme(@Nullable OnlineModule module) {
+        return module != null && ((module.getReadmeHTML() != null && !module.getReadmeHTML().isEmpty())
+                || (module.getReadme() != null && !module.getReadme().isEmpty()));
+    }
+
+    // Fetches the module's rendered README from its GitHub repo. When `loaded`
+    // is non-null the detail JSON already succeeded (valid releases, README is a
+    // bonus) and is always published; when null, the JSON mirrors were
+    // unreachable, so we enrich the cached summary and surface `error` only if
+    // even the GitHub fetch fails.
+    private void loadReadmeFromGithub(String packageName, @Nullable OnlineModule loaded, @Nullable Throwable error) {
+        OnlineModule target = loaded != null ? loaded : onlineModules.get(packageName);
+        if (target == null) {
+            if (error != null) {
+                for (RepoListener listener : listeners) {
+                    listener.onThrowable(error);
+                }
+            }
+            return;
+        }
+        App.getOkHttpClient().newCall(new Request.Builder()
+                .url(String.format(moduleGithubReadmeUrl, packageName))
+                .header("Accept", "application/vnd.github.html+json")
+                .build()).enqueue(new Callback() {
+            @Override
+            public void onFailure(@NonNull Call call, @NonNull IOException e) {
+                Log.e(App.TAG, call.request().url() + e.getMessage());
+                publishReadmeFallback(packageName, target, null, loaded != null, error);
+            }
+
+            @Override
+            public void onResponse(@NonNull Call call, @NonNull Response response) {
+                String html = null;
+                try (response) {
+                    if (response.isSuccessful()) {
+                        ResponseBody body = response.body();
+                        if (body != null) {
+                            String bodyString = body.string();
+                            if (!bodyString.trim().isEmpty()) {
+                                html = bodyString;
+                            }
+                        }
+                    } else {
+                        Log.e(App.TAG, "Unexpected response " + response.code() + " from " + call.request().url());
+                    }
+                } catch (Throwable t) {
+                    Log.e(App.TAG, Log.getStackTraceString(t));
+                }
+                publishReadmeFallback(packageName, target, html, loaded != null, error);
+            }
+        });
+    }
+
+    private void publishReadmeFallback(String packageName, OnlineModule module, @Nullable String readmeHTML, boolean detailLoaded, @Nullable Throwable error) {
+        if (readmeHTML != null) {
+            module.setReadmeHTML(readmeHTML);
+            onlineModules.replace(packageName, module);
+        }
+        if (detailLoaded || readmeHTML != null) {
+            // The releases are already valid, or we recovered a README: publish
+            // the (possibly enriched) module to the UI.
+            for (RepoListener listener : listeners) {
+                listener.onModuleReleasesLoaded(module);
+            }
+        } else if (error != null) {
             for (RepoListener listener : listeners) {
                 listener.onThrowable(error);
             }

--- a/app/src/main/java/org/lsposed/manager/ui/fragment/RepoItemFragment.java
+++ b/app/src/main/java/org/lsposed/manager/ui/fragment/RepoItemFragment.java
@@ -109,6 +109,8 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
     OnlineModule module;
     private ReleaseAdapter releaseAdapter;
     private InformationAdapter informationAdapter;
+    private boolean remoteModuleLoadRequested = false;
+    private boolean releaseLoadRequestedByUser = false;
 
     @Nullable
     @Override
@@ -147,6 +149,7 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
         releaseAdapter = new ReleaseAdapter();
         informationAdapter = new InformationAdapter();
         RepoLoader.getInstance().addListener(this);
+        loadRemoteModuleIfReadmeMissing();
         return binding.getRoot();
     }
 
@@ -184,7 +187,7 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
             } else {
                 direction = "ltr";
             }
-            if (text == null) {
+            if (TextUtils.isEmpty(text)) {
                 text = "<center>" + App.getInstance().getString(R.string.list_empty) + "</center>";
             }
             if (ResourceUtils.isNightMode(getResources().getConfiguration())) {
@@ -238,6 +241,43 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
         }
     }
 
+    @Nullable
+    private OnlineModule refreshModuleFromRepo() {
+        if (module == null || module.getName() == null) return module;
+        var updatedModule = RepoLoader.getInstance().getOnlineModule(module.getName());
+        if (updatedModule != null) {
+            module = updatedModule;
+        }
+        return module;
+    }
+
+    private boolean hasReadme(@Nullable OnlineModule module) {
+        return module != null && (!TextUtils.isEmpty(module.getReadmeHTML()) || !TextUtils.isEmpty(module.getReadme()));
+    }
+
+    private void loadRemoteModuleIfReadmeMissing() {
+        var currentModule = refreshModuleFromRepo();
+        if (currentModule == null || currentModule.getName() == null) return;
+        if (remoteModuleLoadRequested || currentModule.releasesLoaded || hasReadme(currentModule)) return;
+
+        remoteModuleLoadRequested = true;
+        RepoLoader.getInstance().loadRemoteReleases(currentModule.getName());
+    }
+
+    @Nullable
+    private String getModuleReadme() {
+        var currentModule = refreshModuleFromRepo();
+        if (currentModule == null) return null;
+        String readme = currentModule.getReadmeHTML();
+        if (TextUtils.isEmpty(readme)) {
+            readme = currentModule.getReadme();
+        }
+        if (TextUtils.isEmpty(readme)) {
+            loadRemoteModuleIfReadmeMissing();
+        }
+        return readme;
+    }
+
     @Override
     public void onCreateMenu(@NonNull Menu menu, @NonNull MenuInflater menuInflater) {
 
@@ -261,15 +301,26 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
     }
 
     @Override
+    public void onRepoLoaded() {
+        refreshModuleFromRepo();
+        loadRemoteModuleIfReadmeMissing();
+        if (releaseAdapter != null) {
+            runAsync(releaseAdapter::loadItems);
+        }
+    }
+
+    @Override
     public void onModuleReleasesLoaded(OnlineModule module) {
+        if (this.module == null || module == null || !TextUtils.equals(this.module.getName(), module.getName())) return;
         this.module = module;
         var repoLoader = RepoLoader.getInstance();
         if (releaseAdapter != null) {
             runAsync(releaseAdapter::loadItems);
         }
-        if ((repoLoader.getReleases(module.getName()) != null ? repoLoader.getReleases(module.getName()).size() : 1) == 1) {
+        if (releaseLoadRequestedByUser && (repoLoader.getReleases(module.getName()) != null ? repoLoader.getReleases(module.getName()).size() : 1) == 1) {
             showHint(R.string.module_release_no_more, true);
         }
+        releaseLoadRequestedByUser = false;
     }
 
     @Override
@@ -456,6 +507,7 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
                     if (holder.progress.getVisibility() == View.GONE) {
                         holder.title.setVisibility(View.GONE);
                         holder.progress.show();
+                        releaseLoadRequestedByUser = true;
                         RepoLoader.getInstance().loadRemoteReleases(module.getName());
                     }
                 });
@@ -611,8 +663,16 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
         }
     }
 
-    public static class ReadmeFragment extends BorderFragment {
+    public static class ReadmeFragment extends BorderFragment implements RepoLoader.RepoListener {
         ItemRepoReadmeBinding binding;
+
+        private void renderReadme() {
+            var parent = getParentFragment();
+            if (!(parent instanceof RepoItemFragment) || binding == null) return;
+
+            var repoItemFragment = (RepoItemFragment) parent;
+            repoItemFragment.renderGithubMarkdown(binding.readme, repoItemFragment.getModuleReadme());
+        }
 
         @Nullable
         @Override
@@ -624,11 +684,38 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
                 }
                 return null;
             }
-            var repoItemFragment = (RepoItemFragment) parent;
             binding = ItemRepoReadmeBinding.inflate(getLayoutInflater(), container, false);
-            repoItemFragment.renderGithubMarkdown(binding.readme, repoItemFragment.module.getReadmeHTML());
+            renderReadme();
             borderView = binding.scrollView;
+            RepoLoader.getInstance().addListener(this);
             return binding.getRoot();
+        }
+
+        @Override
+        public void onRepoLoaded() {
+            if (binding != null) {
+                runOnUiThread(this::renderReadme);
+            }
+        }
+
+        @Override
+        public void onModuleReleasesLoaded(OnlineModule module) {
+            if (binding != null) {
+                var parent = getParentFragment();
+                if (parent instanceof RepoItemFragment) {
+                    var repoItemFragment = (RepoItemFragment) parent;
+                    if (repoItemFragment.module != null && TextUtils.equals(repoItemFragment.module.getName(), module.getName())) {
+                        runOnUiThread(this::renderReadme);
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void onDestroyView() {
+            RepoLoader.getInstance().removeListener(this);
+            binding = null;
+            super.onDestroyView();
         }
 
         @Override

--- a/app/src/main/java/org/lsposed/manager/ui/fragment/RepoItemFragment.java
+++ b/app/src/main/java/org/lsposed/manager/ui/fragment/RepoItemFragment.java
@@ -302,7 +302,10 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
 
     @Override
     public void onRepoLoaded() {
-        refreshModuleFromRepo();
+        var currentModule = refreshModuleFromRepo();
+        if (!hasReadme(currentModule)) {
+            remoteModuleLoadRequested = false;
+        }
         loadRemoteModuleIfReadmeMissing();
         if (releaseAdapter != null) {
             runAsync(releaseAdapter::loadItems);
@@ -325,6 +328,8 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
 
     @Override
     public void onThrowable(Throwable t) {
+        remoteModuleLoadRequested = false;
+        releaseLoadRequestedByUser = false;
         if (releaseAdapter != null) {
             runAsync(releaseAdapter::loadItems);
         }

--- a/app/src/main/java/org/lsposed/manager/ui/fragment/RepoItemFragment.java
+++ b/app/src/main/java/org/lsposed/manager/ui/fragment/RepoItemFragment.java
@@ -297,6 +297,7 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
     public void onDestroyView() {
         super.onDestroyView();
         RepoLoader.getInstance().removeListener(this);
+        remoteModuleLoadRequested = false;
         binding = null;
     }
 

--- a/app/src/main/java/org/lsposed/manager/ui/fragment/RepoItemFragment.java
+++ b/app/src/main/java/org/lsposed/manager/ui/fragment/RepoItemFragment.java
@@ -313,6 +313,7 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
     public void onModuleReleasesLoaded(OnlineModule module) {
         if (this.module == null || module == null || !TextUtils.equals(this.module.getName(), module.getName())) return;
         this.module = module;
+        remoteModuleLoadRequested = false;
         var repoLoader = RepoLoader.getInstance();
         if (releaseAdapter != null) {
             runAsync(releaseAdapter::loadItems);

--- a/app/src/main/java/org/lsposed/manager/ui/fragment/RepoItemFragment.java
+++ b/app/src/main/java/org/lsposed/manager/ui/fragment/RepoItemFragment.java
@@ -479,7 +479,12 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
         public void loadItems() {
             var channels = resources.getStringArray(R.array.update_channel_values);
             var channel = App.getPreferences().getString("update_channel", channels[0]);
-            var releases = RepoLoader.getInstance().getReleases(module.getName());
+            // Prefer this fragment's module when its releases were already loaded
+            // in full; a repo refresh may have replaced RepoLoader's entry with
+            // the modules.json summary, whose truncated release list would
+            // shadow the complete data we already fetched.
+            List<Release> releases = module.releasesLoaded ? module.getReleases() : null;
+            if (releases == null) releases = RepoLoader.getInstance().getReleases(module.getName());
             if (releases == null) releases = module.getReleases();
             List<Release> tmpList;
             if (channel.equals(channels[0])) {

--- a/app/src/main/java/org/lsposed/manager/ui/fragment/RepoItemFragment.java
+++ b/app/src/main/java/org/lsposed/manager/ui/fragment/RepoItemFragment.java
@@ -302,10 +302,7 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
 
     @Override
     public void onRepoLoaded() {
-        var currentModule = refreshModuleFromRepo();
-        if (!hasReadme(currentModule)) {
-            remoteModuleLoadRequested = false;
-        }
+        refreshModuleFromRepo();
         loadRemoteModuleIfReadmeMissing();
         if (releaseAdapter != null) {
             runAsync(releaseAdapter::loadItems);
@@ -690,9 +687,9 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
                 return null;
             }
             binding = ItemRepoReadmeBinding.inflate(getLayoutInflater(), container, false);
-            renderReadme();
             borderView = binding.scrollView;
             RepoLoader.getInstance().addListener(this);
+            renderReadme();
             return binding.getRoot();
         }
 

--- a/app/src/main/java/org/lsposed/manager/ui/fragment/RepoItemFragment.java
+++ b/app/src/main/java/org/lsposed/manager/ui/fragment/RepoItemFragment.java
@@ -160,6 +160,7 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
 
         String modulePackageName = getArguments() == null ? null : getArguments().getString("modulePackageName");
         module = RepoLoader.getInstance().getOnlineModule(modulePackageName);
+        Log.i(App.TAG, "RepoItem: open " + modulePackageName + " -> module " + (module == null ? "NOT FOUND (repoLoaded=" + RepoLoader.getInstance().isRepoLoaded() + "), navigating back" : "found"));
         if (module == null) {
             if (!safeNavigate(R.id.action_repo_item_fragment_to_repo_fragment)) {
                 safeNavigate(R.id.repo_nav);
@@ -714,6 +715,8 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
                 // renderGithubMarkdown fall back to the empty placeholder.
                 display = null;
             }
+            var pkg = repoItemFragment.module == null ? null : repoItemFragment.module.getName();
+            Log.i(App.TAG, "RepoItem: render README for " + pkg + " -> " + (!TextUtils.isEmpty(readme) ? "content" : repoItemFragment.isModuleDetailLoading() ? "loading" : "empty"));
             // onRepoLoaded fires on every repo load and channel change; skip the
             // WebView reload when the rendered content has not actually changed
             // to avoid flicker.

--- a/app/src/main/java/org/lsposed/manager/ui/fragment/RepoItemFragment.java
+++ b/app/src/main/java/org/lsposed/manager/ui/fragment/RepoItemFragment.java
@@ -246,7 +246,15 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
         if (module == null || module.getName() == null) return module;
         var updatedModule = RepoLoader.getInstance().getOnlineModule(module.getName());
         if (updatedModule != null) {
-            module = updatedModule;
+            // A repo refresh can replace RepoLoader's entry with the summary
+            // object from modules.json, which lacks README/release detail that
+            // was already fetched for this fragment. Keep the richer instance so
+            // the UI does not flicker back to empty/truncated content.
+            var currentHasDetail = module.releasesLoaded || hasReadme(module);
+            var updatedHasDetail = updatedModule.releasesLoaded || hasReadme(updatedModule);
+            if (!currentHasDetail || updatedHasDetail) {
+                module = updatedModule;
+            }
         }
         return module;
     }

--- a/app/src/main/java/org/lsposed/manager/ui/fragment/RepoItemFragment.java
+++ b/app/src/main/java/org/lsposed/manager/ui/fragment/RepoItemFragment.java
@@ -499,8 +499,9 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
                     return !(name != null && name.startsWith("snapshot")) && !(name != null && name.startsWith("nightly"));
                 }).collect(Collectors.toList()) : null;
             } else tmpList = releases;
+            List<Release> newItems = tmpList != null ? tmpList : new ArrayList<>();
             runOnUiThread(() -> {
-                items = tmpList;
+                items = newItems;
                 notifyDataSetChanged();
             });
         }
@@ -682,13 +683,22 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
 
     public static class ReadmeFragment extends BorderFragment implements RepoLoader.RepoListener {
         ItemRepoReadmeBinding binding;
+        private String renderedReadme;
+        private boolean readmeRendered = false;
 
         private void renderReadme() {
             var parent = getParentFragment();
             if (!(parent instanceof RepoItemFragment) || binding == null) return;
 
             var repoItemFragment = (RepoItemFragment) parent;
-            repoItemFragment.renderGithubMarkdown(binding.readme, repoItemFragment.getModuleReadme());
+            var readme = repoItemFragment.getModuleReadme();
+            // onRepoLoaded fires on every repo load and channel change; skip the
+            // WebView reload when the content has not actually changed to avoid
+            // flicker.
+            if (readmeRendered && TextUtils.equals(renderedReadme, readme)) return;
+            renderedReadme = readme;
+            readmeRendered = true;
+            repoItemFragment.renderGithubMarkdown(binding.readme, readme);
         }
 
         @Nullable
@@ -732,6 +742,8 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
         public void onDestroyView() {
             RepoLoader.getInstance().removeListener(this);
             binding = null;
+            renderedReadme = null;
+            readmeRendered = false;
             super.onDestroyView();
         }
 

--- a/app/src/main/java/org/lsposed/manager/ui/fragment/RepoItemFragment.java
+++ b/app/src/main/java/org/lsposed/manager/ui/fragment/RepoItemFragment.java
@@ -272,6 +272,13 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
         RepoLoader.getInstance().loadRemoteReleases(currentModule.getName());
     }
 
+    // True while the per-module detail (which carries the README) is still being
+    // fetched, so the README tab can show a loading state instead of the empty
+    // placeholder on a slow connection.
+    private boolean isModuleDetailLoading() {
+        return remoteModuleLoadRequested;
+    }
+
     @Nullable
     private String getModuleReadme() {
         var currentModule = refreshModuleFromRepo();
@@ -691,14 +698,29 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
             if (!(parent instanceof RepoItemFragment) || binding == null) return;
 
             var repoItemFragment = (RepoItemFragment) parent;
+            // getModuleReadme() also kicks off the per-module fetch when the
+            // README is missing, so query the loading state afterwards.
             var readme = repoItemFragment.getModuleReadme();
+            String display;
+            if (!TextUtils.isEmpty(readme)) {
+                display = readme;
+            } else if (repoItemFragment.isModuleDetailLoading()) {
+                // Detail is still downloading (e.g. slow connection); show a
+                // loading placeholder rather than the empty state so users are
+                // not misled into thinking the module has no README.
+                display = "<center>" + getString(R.string.loading) + "</center>";
+            } else {
+                // Detail has loaded and there is genuinely no README; let
+                // renderGithubMarkdown fall back to the empty placeholder.
+                display = null;
+            }
             // onRepoLoaded fires on every repo load and channel change; skip the
-            // WebView reload when the content has not actually changed to avoid
-            // flicker.
-            if (readmeRendered && TextUtils.equals(renderedReadme, readme)) return;
-            renderedReadme = readme;
+            // WebView reload when the rendered content has not actually changed
+            // to avoid flicker.
+            if (readmeRendered && TextUtils.equals(renderedReadme, display)) return;
+            renderedReadme = display;
             readmeRendered = true;
-            repoItemFragment.renderGithubMarkdown(binding.readme, readme);
+            repoItemFragment.renderGithubMarkdown(binding.readme, display);
         }
 
         @Nullable
@@ -735,6 +757,16 @@ public class RepoItemFragment extends BaseFragment implements RepoLoader.RepoLis
                         runOnUiThread(this::renderReadme);
                     }
                 }
+            }
+        }
+
+        @Override
+        public void onThrowable(Throwable t) {
+            // The fetch failed; re-render so the tab leaves the loading state
+            // (the parent already reset the in-flight flag before this runnable
+            // executes) instead of spinning forever.
+            if (binding != null) {
+                runOnUiThread(this::renderReadme);
             }
         }
 

--- a/app/src/main/java/org/lsposed/manager/util/CloudflareDNS.java
+++ b/app/src/main/java/org/lsposed/manager/util/CloudflareDNS.java
@@ -1,6 +1,7 @@
 package org.lsposed.manager.util;
 
 import android.os.Build;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 
@@ -10,6 +11,7 @@ import java.net.InetAddress;
 import java.net.Proxy;
 import java.net.ProxySelector;
 import java.net.UnknownHostException;
+import java.time.Duration;
 import java.util.List;
 
 import okhttp3.ConnectionSpec;
@@ -25,6 +27,10 @@ public final class CloudflareDNS implements Dns {
     public boolean DoH = App.getPreferences().getBoolean("doh", false);
     public boolean noProxy = ProxySelector.getDefault().select(url.uri()).get(0) == Proxy.NO_PROXY;
     private final Dns cloudflare;
+    // Set once the DoH resolver proves unreachable (e.g. Cloudflare blocked on
+    // this network) so we stop paying its timeout on every subsequent lookup and
+    // use the system resolver for the rest of the session.
+    private volatile boolean dohUnavailable = false;
 
     public CloudflareDNS() {
         var trustManager = Platform.get().platformTrustManager();
@@ -42,6 +48,11 @@ public final class CloudflareDNS implements Dns {
                         .cache(App.getOkHttpCache())
                         .sslSocketFactory(new NoSniFactory(), trustManager)
                         .connectionSpecs(List.of(tls))
+                        // Fail fast when the DoH endpoint is blocked so the
+                        // system-DNS fallback kicks in quickly instead of
+                        // stalling on the default 10s connect timeout.
+                        .connectTimeout(Duration.ofSeconds(3))
+                        .callTimeout(Duration.ofSeconds(5))
                         .build());
         try {
             builder.bootstrapDnsHosts(List.of(
@@ -57,10 +68,18 @@ public final class CloudflareDNS implements Dns {
     @NonNull
     @Override
     public List<InetAddress> lookup(@NonNull String hostname) throws UnknownHostException {
-        if (DoH && noProxy) {
-            return cloudflare.lookup(hostname);
-        } else {
-            return SYSTEM.lookup(hostname);
+        if (DoH && noProxy && !dohUnavailable) {
+            try {
+                return cloudflare.lookup(hostname);
+            } catch (UnknownHostException e) {
+                // The DoH resolver is unreachable on this network (e.g. Cloudflare
+                // is blocked). Fall back to the system resolver so the app keeps
+                // working instead of failing every lookup, and skip DoH for the
+                // rest of the session.
+                dohUnavailable = true;
+                Log.w(App.TAG, "DoH resolver unreachable, falling back to system DNS for this session: " + e.getMessage());
+            }
         }
+        return SYSTEM.lookup(hostname);
     }
 }


### PR DESCRIPTION
﻿## Summary

This fixes the module repository loader against the current LSPosed repository endpoints.

It builds on the investigation and approach from #747 by @byemaxx, with two follow-up adjustments:

- keep the "Open in browser" action on the public `modules.lsposed.org` web page, because `backup.modules.lsposed.org/module/<package>` returns 404 without the `.json` suffix
- report non-2xx / empty HTTP responses as repository load failures instead of silently leaving the UI refreshing

## Root Cause

The old module list API currently fails from the manager path:

- `https://modules.lsposed.org/modules.json` returns 403
- `https://modules-blogcdn.lsposed.org/modules.json` returns 418
- `https://modules-cloudflare.lsposed.org/modules.json` is no longer reliable
- `https://backup.modules.lsposed.org/modules.json` returns the expected JSON payload

Also, entries from `modules.json` may not include README content anymore, while the per-module JSON endpoint still does. The manager therefore needs to load `module/<package>.json` before rendering the README tab when the list entry has no README.

## Changes

- Use `https://backup.modules.lsposed.org/` for module repository JSON API calls.
- Treat unsuccessful HTTP responses and empty response bodies as load failures.
- Restore the loaded state after a failed repository refresh so the UI does not remain in an endless refresh state.
- Load full per-module JSON when README content is missing, then refresh the README tab.
- Keep browser navigation pointed at `https://modules.lsposed.org/module/<package>`.

## Related

- Fixes #715
- Addresses the repository loading regression discussed in #746
- Follow-up to #747

## Validation

- `./gradlew.bat --no-daemon :app:compileDebugJavaWithJavac`
- `./gradlew.bat --no-daemon :app:assembleDebug`
- Verified endpoint behavior with `curl`:
  - `backup.modules.lsposed.org/modules.json` -> 200 JSON
  - `backup.modules.lsposed.org/module/com.luckyzyx.luckytool.json` -> 200 JSON
  - `backup.modules.lsposed.org/module/com.luckyzyx.luckytool` -> 404
  - `modules.lsposed.org/module/com.luckyzyx.luckytool` -> 200 HTML
