### PR TITLE
Guard profile clearing against IPackageManager runtime drift

### DIFF
--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/ManagerService.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/ManagerService.kt
@@ -417,7 +417,7 @@ object ManagerService : ILSPManagerService.Stub() {
   override fun restartFor(intent: Intent) {} // No-op matching original
 
   override fun clearApplicationProfileData(packageName: String) {
-    packageManager?.clearApplicationProfileData(packageName)
+    packageManager?.clearApplicationProfileDataCompat(packageName)
   }
 
   override fun enableStatusNotification() = PreferenceStore.isStatusNotificationEnabled()

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/system/SystemExtensions.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/system/SystemExtensions.kt
@@ -28,6 +28,35 @@ const val MATCH_ALL_FLAGS =
         PackageManager.MATCH_UNINSTALLED_PACKAGES or
         MATCH_ANY_USER
 
+private val clearApplicationProfileDataMethod: Method? by lazy {
+  IPackageManager::class
+      .java
+      .methods
+      .find {
+        it.name == "clearApplicationProfileData" &&
+            it.parameterTypes.contentEquals(arrayOf(String::class.java))
+      }
+      ?.apply { isAccessible = true }
+}
+
+/** Android 17 may omit this hidden IPackageManager method from the runtime framework. */
+fun IPackageManager.clearApplicationProfileDataCompat(packageName: String): Boolean {
+  val method = clearApplicationProfileDataMethod
+  if (method == null) {
+    Log.w(
+        TAG,
+        "Runtime IPackageManager lacks clearApplicationProfileData; skipping profile clear for $packageName")
+    return false
+  }
+
+  return runCatching {
+        method.invoke(this, packageName)
+        true
+      }
+      .onFailure { Log.e(TAG, "clearApplicationProfileDataCompat failed", it.cause ?: it) }
+      .getOrDefault(false)
+}
+
 @Throws(Exception::class)
 private fun IPackageManager.getPackageInfoCompatThrows(
     packageName: String,


### PR DESCRIPTION
On some Android 17 builds, the manager compile flow crashes `VectorDaemon` with a `NoSuchMethodError` in `ManagerService.clearApplicationProfileData()`. The daemon was compiled against a hidden `IPackageManager` stub that declares `clearApplicationProfileData(String)`, but some runtime `framework.jar` variants do not expose that method at all.

We fix the issue by moving profile clearing behind a compatibility wrapper that reflectively probes `IPackageManager` for `clearApplicationProfileData(String)`. When the method is missing, we now log and skip profile clearing instead of crashing the daemon Binder thread.