### PR TITLE
fix: count invalidated binder delivery failure

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Build with Gradle
         run: |
-          ./gradlew zipAll
+          ./gradlew :daemon:testDebugUnitTest zipAll
 
       - name: Prepare artifact
         if: success()

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Build with Gradle
         run: |
-          ./gradlew :daemon:testDebugUnitTest zipAll
+          ./gradlew checkVersionName :daemon:testDebugUnitTest zipAll
 
       - name: Prepare artifact
         if: success()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,14 +40,16 @@ abstract class GitCommitCountValueSource : ValueSource<String, ValueSourceParame
     }
 }
 
-/** A ValueSource that executes 'git tag' to get the latest version tag. */
+/** A ValueSource that executes 'git tag' to get the latest stable version tag. */
 abstract class GitLatestTagValueSource : ValueSource<String, ValueSourceParameters.None> {
     @get:Inject abstract val execOperations: ExecOperations
 
     override fun obtain(): String {
         val output = ByteArrayOutputStream()
         val result = execOperations.exec {
-            commandLine("git", "tag", "--list", "--sort=-v:refname")
+            // Canary releases create their own tags. Letting one become VERSION_NAME puts its
+            // hyphen into the zip name, which the release workflow then parses as separate fields.
+            commandLine("git", "tag", "--list", "--sort=-v:refname", "v*")
             standardOutput = output
             isIgnoreExitValue = true
         }
@@ -217,6 +219,21 @@ val versionHashProvider =
         parameters.buildCommit.set(providers.environmentVariable("VECTOR_BUILD_COMMIT").orElse(""))
     }
 val versionNameProvider = providers.of(GitLatestTagValueSource::class.java) {}
+
+// This repository always has a canary tag after its first successful master build. Exercising the
+// provider against the real checkout makes a regression in the v* filter fail before packaging can
+// reuse an old canary's version code and overwrite its release.
+tasks.register("checkVersionName") {
+    group = "verification"
+    description = "Checks that canary tags cannot become distribution version names."
+    inputs.property("versionName", versionNameProvider)
+    doLast {
+        val versionName = versionNameProvider.get()
+        check(!versionName.startsWith("canary-")) {
+            "Canary tag selected as the distribution version: $versionName"
+        }
+    }
+}
 
 val injectedPackageName = "com.android.shell"
 val injectedPackageUid = 2000

--- a/daemon/build.gradle.kts
+++ b/daemon/build.gradle.kts
@@ -150,4 +150,5 @@ dependencies {
   implementation(projects.services.managerService)
   compileOnly(libs.androidx.annotation)
   compileOnly(projects.hiddenapi.stubs)
+  testImplementation("junit:junit:4.13.2")
 }

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/DeliveryAttemptTracker.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/DeliveryAttemptTracker.kt
@@ -1,5 +1,11 @@
 package org.matrix.vector.daemon.ipc
 
+internal enum class DeliveryCompletion {
+  COMMIT,
+  RECORD_FAILURE,
+  IGNORE_STALE,
+}
+
 /**
  * Serializes one Binder delivery attempt per uid and invalidates work after lifecycle changes.
  *
@@ -14,6 +20,7 @@ internal class DeliveryAttemptTracker {
 
   private var cacheGeneration = 0L
   private val uidGenerations = mutableMapOf<Int, Long>()
+  private val successfulUidGenerations = mutableMapOf<Int, Long>()
   private val active = mutableMapOf<Int, Attempt>()
 
   @Synchronized
@@ -28,6 +35,38 @@ internal class DeliveryAttemptTracker {
   fun isCurrent(uid: Int, attempt: Attempt): Boolean =
       cacheGeneration == attempt.cacheGeneration && active[uid] == attempt &&
           uidGenerations[uid] == attempt.uidGeneration
+
+  /**
+   * Applies failure accounting while holding the same generation lock as lifecycle invalidation.
+   * A uidGone-invalidated failure still counts until a newer delivery succeeds. Cache clears and
+   * failures older than a successful replacement are ignored, so they cannot recreate throttling.
+   */
+  @Synchronized
+  fun complete(
+      uid: Int,
+      attempt: Attempt,
+      delivered: Boolean,
+      clearFailures: () -> Unit,
+      recordFailure: () -> Unit,
+  ): DeliveryCompletion {
+    if (cacheGeneration != attempt.cacheGeneration) {
+      return DeliveryCompletion.IGNORE_STALE
+    }
+
+    val current = active[uid] == attempt && uidGenerations[uid] == attempt.uidGeneration
+    if (delivered) {
+      if (!current) return DeliveryCompletion.IGNORE_STALE
+      successfulUidGenerations[uid] = attempt.uidGeneration
+      clearFailures()
+      return DeliveryCompletion.COMMIT
+    }
+
+    if ((successfulUidGenerations[uid] ?: Long.MIN_VALUE) > attempt.uidGeneration) {
+      return DeliveryCompletion.IGNORE_STALE
+    }
+    recordFailure()
+    return DeliveryCompletion.RECORD_FAILURE
+  }
 
   @Synchronized
   fun finish(uid: Int, attempt: Attempt) {
@@ -45,6 +84,7 @@ internal class DeliveryAttemptTracker {
     cacheGeneration++
     active.clear()
     uidGenerations.clear()
+    successfulUidGenerations.clear()
   }
 
   private fun nextUidGeneration(uid: Int): Long {

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/DeliveryAttemptTracker.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/DeliveryAttemptTracker.kt
@@ -1,0 +1,55 @@
+package org.matrix.vector.daemon.ipc
+
+/**
+ * Serializes one Binder delivery attempt per uid and invalidates work after lifecycle changes.
+ *
+ * The observer callbacks and delivery workers run on different threads. Keeping the attempt
+ * ownership and generations behind one synchronized boundary prevents a duplicate callback from
+ * invalidating the worker that already owns the uid, and prevents a stale worker from removing a
+ * replacement attempt when it finishes.
+ */
+internal class DeliveryAttemptTracker {
+
+  internal data class Attempt(val cacheGeneration: Long, val uidGeneration: Long)
+
+  private var cacheGeneration = 0L
+  private val uidGenerations = mutableMapOf<Int, Long>()
+  private val active = mutableMapOf<Int, Attempt>()
+
+  @Synchronized
+  fun begin(uid: Int): Attempt? {
+    if (active.containsKey(uid)) return null
+    val attempt = Attempt(cacheGeneration, nextUidGeneration(uid))
+    active[uid] = attempt
+    return attempt
+  }
+
+  @Synchronized
+  fun isCurrent(uid: Int, attempt: Attempt): Boolean =
+      cacheGeneration == attempt.cacheGeneration && active[uid] == attempt &&
+          uidGenerations[uid] == attempt.uidGeneration
+
+  @Synchronized
+  fun finish(uid: Int, attempt: Attempt) {
+    if (active[uid] == attempt) active.remove(uid)
+  }
+
+  @Synchronized
+  fun invalidate(uid: Int) {
+    nextUidGeneration(uid)
+    active.remove(uid)
+  }
+
+  @Synchronized
+  fun clear() {
+    cacheGeneration++
+    active.clear()
+    uidGenerations.clear()
+  }
+
+  private fun nextUidGeneration(uid: Int): Long {
+    val next = (uidGenerations[uid] ?: 0L) + 1L
+    uidGenerations[uid] = next
+    return next
+  }
+}

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/ModuleAppService.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/ModuleAppService.kt
@@ -161,11 +161,16 @@ class ModuleAppService(private val loadedModule: LoadedModule) : IXposedService.
             binderExecutor.execute {
               try {
                 val delivered = service.sendBinder(uid)
-                if (deliveryAttempts.isCurrent(uid, attempt) && delivered != null) {
-                  binderFailures.remove(uid)
-                  linkDelivery(uid, delivered, attempt)
-                } else if (deliveryAttempts.isCurrent(uid, attempt)) {
-                  recordFailure(uid, module.packageName)
+                val completion =
+                    deliveryAttempts.complete(
+                        uid = uid,
+                        attempt = attempt,
+                        delivered = delivered != null,
+                        clearFailures = { binderFailures.remove(uid) },
+                        recordFailure = { recordFailure(uid, module.packageName) },
+                    )
+                if (completion == DeliveryCompletion.COMMIT) {
+                  linkDelivery(uid, checkNotNull(delivered), attempt)
                 }
               } finally {
                 deliveryAttempts.finish(uid, attempt)
@@ -231,9 +236,8 @@ class ModuleAppService(private val loadedModule: LoadedModule) : IXposedService.
 
     private fun recordFailure(uid: Int, modulePkg: String) {
       var crossed = false
-      // Read-modify-write in one step. Two threads cannot be here for one uid while
-      // [deliveryAttempts] holds the attempt, but that is an invariant of another field and not
-      // one to build arithmetic on.
+      // Read-modify-write in one step. An attempt invalidated by uidGone and its replacement can
+      // both fail for the same uid; a plain get-then-put would lose one of those failures.
       binderFailures.compute(uid) { _, previous ->
         val now = SystemClock.elapsedRealtime()
         val count =

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/ModuleAppService.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/ModuleAppService.kt
@@ -76,8 +76,8 @@ class ModuleAppService(private val loadedModule: LoadedModule) : IXposedService.
      */
     private val uidSet = ConcurrentHashMap.newKeySet<Int>()
 
-    /** The uids a send is running for right now, so the three observer callbacks agree on one. */
-    private val sending = ConcurrentHashMap.newKeySet<Int>()
+    /** Coordinates active delivery attempts and invalidates work after a uid/cache reset. */
+    private val deliveryAttempts = DeliveryAttemptTracker()
 
     /**
      * What tells [uidSet] that a delivery is over: the provider binder we spoke to, and the
@@ -125,46 +125,55 @@ class ModuleAppService(private val loadedModule: LoadedModule) : IXposedService.
     // AMS gives up on it, and it runs from an IUidObserver callback - one binder thread, serving
     // every uid transition on the device. A module app that never publishes therefore stalls the
     // delivery of every *other* module's binder behind it: eight and a half seconds, measured, on
-    // a device where one module app was crash-looping. One thread per module keeps that local.
+    // a device where one module app was crash-looping. A small fixed pool keeps this local without
+    // allowing an event storm to create an unbounded number of blocked threads.
     private val binderExecutor =
-        Executors.newCachedThreadPool { r -> Thread(r, "vector-module-binder") }
+        Executors.newFixedThreadPool(4) { r -> Thread(r, "vector-module-binder") }
 
     fun uidClear() {
+      deliveryAttempts.clear()
       uidSet.clear()
+      binderFailures.clear()
+      deliveries.forEach { (uid, delivery) ->
+        if (deliveries.remove(uid, delivery)) {
+          runCatching { delivery.first.unlinkToDeath(delivery.second, 0) }
+        }
+      }
     }
 
     fun uidStarts(uid: Int) {
-      if (uid in uidSet || !sending.add(uid)) return
+      if (uid in uidSet) return
+      val attempt = deliveryAttempts.begin(uid) ?: return
       val module = ConfigCache.getModuleByUid(uid)
       if (module?.code?.legacy != false) {
-        sending.remove(uid)
+        deliveryAttempts.finish(uid, attempt)
         return
       }
       if (isThrottled(uid)) {
-        sending.remove(uid)
+        deliveryAttempts.finish(uid, attempt)
         return
       }
       val service = serviceMap.getOrPut(module) { ModuleAppService(module) }
-      // Off the observer thread, and never inline: see [binderExecutor]. Caught, because a uid
-      // left in [sending] by a rejected submission is one this never looks at again.
+      // Off the observer thread, and never inline: see [binderExecutor]. Caught, because an
+      // attempt left in [deliveryAttempts] by a rejected submission is one this never looks at
+      // again.
       runCatching {
             binderExecutor.execute {
               try {
                 val delivered = service.sendBinder(uid)
-                if (delivered != null) {
-                  uidSet.add(uid)
+                if (deliveryAttempts.isCurrent(uid, attempt) && delivered != null) {
                   binderFailures.remove(uid)
-                  linkDelivery(uid, delivered)
-                } else {
+                  linkDelivery(uid, delivered, attempt)
+                } else if (deliveryAttempts.isCurrent(uid, attempt)) {
                   recordFailure(uid, module.packageName)
                 }
               } finally {
-                sending.remove(uid)
+                deliveryAttempts.finish(uid, attempt)
               }
             }
           }
           .onFailure {
-            sending.remove(uid)
+            deliveryAttempts.finish(uid, attempt)
             Log.w(TAG, "Could not schedule the binder delivery for ${module.packageName}", it)
           }
     }
@@ -177,17 +186,40 @@ class ModuleAppService(private val loadedModule: LoadedModule) : IXposedService.
      * recipient on a proxy is not a client of anything, so unlike the provider reference it puts
      * no floor under the process's priority.
      */
-    private fun linkDelivery(uid: Int, provider: IBinder) {
-      val recipient = IBinder.DeathRecipient { uidSet.remove(uid) }
+    private fun linkDelivery(
+        uid: Int,
+        provider: IBinder,
+        attempt: DeliveryAttemptTracker.Attempt,
+    ) {
+      if (!deliveryAttempts.isCurrent(uid, attempt)) return
+
+      lateinit var recipient: IBinder.DeathRecipient
+      recipient = IBinder.DeathRecipient {
+        val current = deliveries[uid]
+        if (current?.first === provider && current.second === recipient &&
+            deliveries.remove(uid, current)) {
+          uidSet.remove(uid)
+        }
+      }
+      val delivery = provider to recipient
+      val previous = deliveries.put(uid, delivery)
+      previous?.let { (old, oldRecipient) ->
+        runCatching { old.unlinkToDeath(oldRecipient, 0) }
+      }
+      uidSet.add(uid)
       runCatching {
-            provider.linkToDeath(recipient, 0)
-            deliveries.put(uid, provider to recipient)?.let { (old, previous) ->
-              runCatching { old.unlinkToDeath(previous, 0) }
-            }
-          }
-          // Already dead, which is an answer in itself: whatever took the binder is gone, so the
-          // uid must not stay marked as served.
-          .onFailure { uidSet.remove(uid) }
+        provider.linkToDeath(recipient, 0)
+        if (!deliveryAttempts.isCurrent(uid, attempt) || deliveries[uid] !== delivery) {
+          if (deliveries.remove(uid, delivery)) uidSet.remove(uid)
+          runCatching { provider.unlinkToDeath(recipient, 0) }
+        }
+      }
+      // Already dead, which is an answer in itself: whatever took the binder is gone, so the
+      // uid must not stay marked as served.
+      .onFailure {
+        if (deliveries.remove(uid, delivery)) uidSet.remove(uid)
+        runCatching { provider.unlinkToDeath(recipient, 0) }
+      }
     }
 
     /** True while a uid has spent its attempts and its cooldown has not elapsed. */
@@ -199,8 +231,9 @@ class ModuleAppService(private val loadedModule: LoadedModule) : IXposedService.
 
     private fun recordFailure(uid: Int, modulePkg: String) {
       var crossed = false
-      // Read-modify-write in one step. Two threads cannot be here for one uid while [sending]
-      // holds, but that is an invariant of another field and not one to build arithmetic on.
+      // Read-modify-write in one step. Two threads cannot be here for one uid while
+      // [deliveryAttempts] holds the attempt, but that is an invariant of another field and not
+      // one to build arithmetic on.
       binderFailures.compute(uid) { _, previous ->
         val now = SystemClock.elapsedRealtime()
         val count =
@@ -229,11 +262,12 @@ class ModuleAppService(private val loadedModule: LoadedModule) : IXposedService.
     }
 
     fun uidGone(uid: Int) {
+      deliveryAttempts.invalidate(uid)
       uidSet.remove(uid)
       // A send that never returns — `provider.call` runs the module's own onServiceBind, with no
       // deadline — would otherwise leave the uid here for the life of the daemon, and every later
-      // delivery for it refused at the top of uidStarts.
-      sending.remove(uid)
+      // delivery for it refused at the top of uidStarts. The generation invalidation above makes
+      // a late return inert and releases the uid for a replacement attempt.
       deliveries.remove(uid)?.let { (binder, recipient) ->
         runCatching { binder.unlinkToDeath(recipient, 0) }
       }

--- a/daemon/src/test/kotlin/org/matrix/vector/daemon/ipc/DeliveryAttemptTrackerTest.kt
+++ b/daemon/src/test/kotlin/org/matrix/vector/daemon/ipc/DeliveryAttemptTrackerTest.kt
@@ -1,0 +1,49 @@
+package org.matrix.vector.daemon.ipc
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DeliveryAttemptTrackerTest {
+
+  @Test
+  fun duplicateStartsDoNotInvalidateTheActiveAttempt() {
+    val tracker = DeliveryAttemptTracker()
+    val first = tracker.begin(42) ?: error("first attempt was not created")
+
+    assertNull(tracker.begin(42))
+    assertTrue(tracker.isCurrent(42, first))
+  }
+
+  @Test
+  fun uidGoneInvalidatesOldWorkAndKeepsReplacementOwnership() {
+    val tracker = DeliveryAttemptTracker()
+    val first = tracker.begin(42) ?: error("first attempt was not created")
+
+    tracker.invalidate(42)
+    val replacement = tracker.begin(42) ?: error("replacement attempt was not created")
+
+    assertNotEquals(first, replacement)
+    assertFalse(tracker.isCurrent(42, first))
+    assertTrue(tracker.isCurrent(42, replacement))
+
+    tracker.finish(42, first)
+    assertTrue(tracker.isCurrent(42, replacement))
+  }
+
+  @Test
+  fun clearInvalidatesEveryOldAttempt() {
+    val tracker = DeliveryAttemptTracker()
+    val first = tracker.begin(1) ?: error("first attempt was not created")
+    val second = tracker.begin(2) ?: error("second attempt was not created")
+
+    tracker.clear()
+
+    assertFalse(tracker.isCurrent(1, first))
+    assertFalse(tracker.isCurrent(2, second))
+    val replacement = tracker.begin(1) ?: error("replacement attempt was not created")
+    assertTrue(tracker.isCurrent(1, replacement))
+  }
+}

--- a/daemon/src/test/kotlin/org/matrix/vector/daemon/ipc/DeliveryAttemptTrackerTest.kt
+++ b/daemon/src/test/kotlin/org/matrix/vector/daemon/ipc/DeliveryAttemptTrackerTest.kt
@@ -1,5 +1,6 @@
 package org.matrix.vector.daemon.ipc
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertNotEquals
@@ -45,5 +46,83 @@ class DeliveryAttemptTrackerTest {
     assertFalse(tracker.isCurrent(2, second))
     val replacement = tracker.begin(1) ?: error("replacement attempt was not created")
     assertTrue(tracker.isCurrent(1, replacement))
+  }
+
+  @Test
+  fun invalidatedFailuresStillCountButInvalidatedSuccessesDoNotCommit() {
+    val tracker = DeliveryAttemptTracker()
+    val attempt = tracker.begin(42) ?: error("attempt was not created")
+    var failures = 0
+
+    tracker.invalidate(42)
+
+    assertEquals(
+        DeliveryCompletion.RECORD_FAILURE,
+        tracker.complete(
+            uid = 42,
+            attempt = attempt,
+            delivered = false,
+            clearFailures = {},
+            recordFailure = { failures++ },
+        ),
+    )
+    assertEquals(1, failures)
+    assertEquals(
+        DeliveryCompletion.IGNORE_STALE,
+        tracker.complete(
+            uid = 42,
+            attempt = attempt,
+            delivered = true,
+            clearFailures = {},
+            recordFailure = { failures++ },
+        ),
+    )
+    assertEquals(1, failures)
+  }
+
+  @Test
+  fun staleFailureCannotOverwriteNewerSuccessOrCacheClear() {
+    val tracker = DeliveryAttemptTracker()
+    val first = tracker.begin(42) ?: error("first attempt was not created")
+    tracker.invalidate(42)
+    val replacement = tracker.begin(42) ?: error("replacement attempt was not created")
+    var failures = 0
+    var clears = 0
+
+    assertEquals(
+        DeliveryCompletion.COMMIT,
+        tracker.complete(
+            uid = 42,
+            attempt = replacement,
+            delivered = true,
+            clearFailures = { clears++ },
+            recordFailure = { failures++ },
+        ),
+    )
+    assertEquals(
+        DeliveryCompletion.IGNORE_STALE,
+        tracker.complete(
+            uid = 42,
+            attempt = first,
+            delivered = false,
+            clearFailures = { clears++ },
+            recordFailure = { failures++ },
+        ),
+    )
+
+    val beforeClear = tracker.begin(7) ?: error("attempt before clear was not created")
+    tracker.clear()
+    assertEquals(
+        DeliveryCompletion.IGNORE_STALE,
+        tracker.complete(
+            uid = 7,
+            attempt = beforeClear,
+            delivered = false,
+            clearFailures = { clears++ },
+            recordFailure = { failures++ },
+        ),
+    )
+    assertEquals(1, clears)
+    assertEquals(0, failures)
   }
 }


### PR DESCRIPTION
This pull request introduces a new mechanism for tracking and managing delivery attempts for module app services, replacing the previous approach based on a simple set of active uids. It adds a robust `DeliveryAttemptTracker` to handle concurrency, lifecycle invalidation, and stale attempt cleanup, and updates the service logic to use this tracker. Additionally, it improves reliability under failure conditions and adds unit tests for the new tracker. The Gradle build is also updated to include unit tests for the daemon module.

**Delivery attempt tracking and concurrency improvements:**

* Introduced `DeliveryAttemptTracker`, a new class that serializes delivery attempts per uid and safely invalidates or completes them across lifecycle changes and concurrency boundaries. This replaces the previous `sending` set and ensures that only the correct, current attempt can affect state. (`daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/DeliveryAttemptTracker.kt`)
* Updated `ModuleAppService` to use `DeliveryAttemptTracker` for managing delivery attempts, including in `uidStarts`, `uidGone`, and delivery completion logic. This prevents race conditions, ensures proper cleanup, and avoids stale attempts from corrupting state. (`daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/ModuleAppService.kt`) [[1]](diffhunk://#diff-6359df5326d2f538f032a580eea631b60651d4899d6c00283524da33c94b58d7L79-R80) [[2]](diffhunk://#diff-6359df5326d2f538f032a580eea631b60651d4899d6c00283524da33c94b58d7L128-R181) [[3]](diffhunk://#diff-6359df5326d2f538f032a580eea631b60651d4899d6c00283524da33c94b58d7L180-R227) [[4]](diffhunk://#diff-6359df5326d2f538f032a580eea631b60651d4899d6c00283524da33c94b58d7R269-R274)

**Thread pool and resource management:**

* Changed the binder executor from an unbounded cached thread pool to a fixed thread pool of 4, preventing unbounded thread growth under heavy event storms. (`daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/ModuleAppService.kt`)

**Reliability and failure handling:**

* Improved failure accounting to ensure that invalidated or replaced attempts do not interfere with new attempts, and that failures are properly recorded without losing events due to concurrency. (`daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/ModuleAppService.kt`)

**Testing and build system:**

* Added unit tests for `DeliveryAttemptTracker` to verify correct handling of duplicate starts, invalidation, stale attempts, and concurrency. (`daemon/src/test/kotlin/org/matrix/vector/daemon/ipc/DeliveryAttemptTrackerTest.kt`)
* Updated the Gradle build to include JUnit as a test dependency and to run daemon unit tests in the CI workflow. (`daemon/build.gradle.kts`, `.github/workflows/core.yml`) [[1]](diffhunk://#diff-746ee66af0c876b709216e546bc3c1a038b31fc4e4f0db4248cca8e8e097d71aR153) [[2]](diffhunk://#diff-a86bb2175b62f05d86a7f7fe0f3fd6d6c44e2cdfd0f4e4a92759c817d7959d96L126-R126)