### PR TITLE
feat(inlinehook): support shadowhook as the inline hook backend

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "external/axml/manifest-editor"]
 	path = external/axml/manifest-editor
 	url = https://github.com/JingMatrix/ManifestEditor.git
+[submodule "external/shadowhook"]
+	path = external/shadowhook
+	url = https://github.com/bytedance/android-inline-hook.git

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ This project is made possible by the following open-source contributions:
 *   [Magisk](https://github.com/topjohnwu/Magisk/): The foundation of Android customization.
 *   [LSPlant](https://github.com/JingMatrix/LSPlant): The core ART hooking engine.
 *   [XposedBridge](https://github.com/rovo89/XposedBridge): The standard Xposed APIs.
-*   [Dobby](https://github.com/JingMatrix/Dobby): Inline hooking implementation.
+*   [Dobby](https://github.com/JingMatrix/Dobby) and [ShadowHook](https://github.com/bytedance/android-inline-hook): Inline hooking implementation.
 *   [LSPosed](https://github.com/LSPosed/LSPosed): Upstream source.
 *   [EdXposed](https://github.com/ElderDrivers/EdXposed): Upstream source, before LSPosed.
 *   [xz-embedded](https://github.com/tukaani-project/xz-embedded): Library decompression utilities.

--- a/daemon/src/main/jni/logcat.cpp
+++ b/daemon/src/main/jni/logcat.cpp
@@ -42,8 +42,9 @@ constexpr auto kModuleTags = std::array{"VectorContext"sv, "VectorLegacyBridge"s
                                         "VectorModuleManager"sv, "XSharedPreferences"sv};
 
 // These route to the 'verbose' stream only.
-constexpr auto kExactTags = std::array{"APatchD"sv, "Dobby"sv,  "KernelSU"sv, "LSPlant"sv,
-                                       "LSPlt"sv,   "Magisk"sv, "SELinux"sv,  "TEESimulator"sv};
+constexpr auto kExactTags = std::array{"APatchD"sv, "Dobby"sv,   "KernelSU"sv, "LSPlant"sv,
+                                       "LSPlt"sv,   "Magisk"sv,  "SELinux"sv,  "TEESimulator"sv,
+                                       "shadowhook_tag"sv};
 
 // Partial matches for dynamic components like Zygisk modules or Vector/LSPosed components.
 constexpr auto kPrefixTags = std::array{"LSPosed"sv, "Vector"sv, "dex2oat"sv, "zygisk"sv};

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/data/PreferenceStore.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/data/PreferenceStore.kt
@@ -3,6 +3,7 @@ package org.matrix.vector.daemon.data
 import android.content.ContentValues
 import android.database.sqlite.SQLiteDatabase
 import org.apache.commons.lang3.SerializationUtilsX
+import org.matrix.vector.ipc.IManagerService
 
 private const val TAG = "VectorPreferenceStore"
 
@@ -100,4 +101,11 @@ object PreferenceStore {
   fun isScopeRequestBlocked(pkg: String): Boolean =
       (getModulePrefs("lspd", 0, "config")["scope_request_blocked"] as? Set<*>)?.contains(pkg) ==
           true
+
+  fun getInlineHookBackend(): Int =
+      getModulePrefs("lspd", 0, "config")["inline_hook_backend"] as? Int
+          ?: IManagerService.INLINE_HOOK_BACKEND_DOBBY
+
+  fun setInlineHookBackend(backend: Int) =
+      updateModulePref("lspd", 0, "config", "inline_hook_backend", backend)
 }

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/FrameworkService.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/FrameworkService.kt
@@ -29,6 +29,8 @@ const val DEX_TRANSACTION_CODE =
     ('_'.code shl 24) or ('D'.code shl 16) or ('E'.code shl 8) or 'X'.code
 const val OBFUSCATION_MAP_TRANSACTION_CODE =
     ('_'.code shl 24) or ('O'.code shl 16) or ('B'.code shl 8) or 'F'.code
+const val INLINE_HOOK_TRANSACTION_CODE =
+    ('_'.code shl 24) or ('I'.code shl 16) or ('H'.code shl 8) or 'B'.code
 
 /**
  * What an injected process asks the framework for — this project's `IFrameworkService`.
@@ -239,6 +241,11 @@ object FrameworkService : IFrameworkService.Stub() {
           reply?.writeString(key)
           reply?.writeString(if (obfuscation) value else key)
         }
+        return true
+      }
+      INLINE_HOOK_TRANSACTION_CODE -> {
+        reply?.writeNoException()
+        reply?.writeInt(ManagerService.getInlineHookBackend())
         return true
       }
     }

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/ManagerService.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/ManagerService.kt
@@ -284,6 +284,15 @@ object ManagerService : IManagerService.Stub() {
     if (isVerboseLogEnabled()) LogcatMonitor.startVerbose() else LogcatMonitor.stopVerbose()
   }
 
+  override fun getInlineHookBackend() = PreferenceStore.getInlineHookBackend()
+
+  override fun setInlineHookBackend(backend: Int) {
+    if (backend == IManagerService.INLINE_HOOK_BACKEND_DOBBY ||
+        backend == IManagerService.INLINE_HOOK_BACKEND_SHADOWHOOK) {
+      PreferenceStore.setInlineHookBackend(backend)
+    }
+  }
+
   override fun getLogParts(verbose: Boolean): List<String> = FileSystem.listLogParts(verbose)
 
   override fun getLogPart(verbose: Boolean, name: String): ParcelFileDescriptor? =

--- a/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/SystemServerService.kt
+++ b/daemon/src/main/kotlin/org/matrix/vector/daemon/ipc/SystemServerService.kt
@@ -138,7 +138,8 @@ object SystemServerService : Binder(), IBinder.DeathRecipient {
         return false
       }
       DEX_TRANSACTION_CODE,
-      OBFUSCATION_MAP_TRANSACTION_CODE -> {
+      OBFUSCATION_MAP_TRANSACTION_CODE,
+      INLINE_HOOK_TRANSACTION_CODE -> {
         return FrameworkService.onTransact(code, data, reply, flags)
       }
       else -> {

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -20,6 +20,42 @@ option(LSPLANT_BUILD_SHARED OFF)
 option(Plugin.SymbolResolver OFF)
 option(FMT_INSTALL OFF)
 
+if (ANDROID_ABI STREQUAL "arm64-v8a" OR ANDROID_ABI STREQUAL "armeabi-v7a")
+    enable_language(ASM)
+    set(SHADOWHOOK_SRC ${CMAKE_CURRENT_SOURCE_DIR}/shadowhook/shadowhook/src/main/cpp)
+    if (ANDROID_ABI STREQUAL "arm64-v8a")
+        set(SHADOWHOOK_ARCH "arm64")
+    else ()
+        set(SHADOWHOOK_ARCH "arm")
+    endif ()
+    file(GLOB SHADOWHOOK_SOURCES
+        ${SHADOWHOOK_SRC}/*.c
+        ${SHADOWHOOK_SRC}/arch/${SHADOWHOOK_ARCH}/*.c
+        ${SHADOWHOOK_SRC}/arch/${SHADOWHOOK_ARCH}/*.S
+        ${SHADOWHOOK_SRC}/common/*.c
+        ${SHADOWHOOK_SRC}/third_party/*/*.c
+    )
+	list(REMOVE_ITEM SHADOWHOOK_SOURCES ${SHADOWHOOK_SRC}/sh_linker.c)
+    list(APPEND SHADOWHOOK_SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/patches/shadowhook/sh_linker.c)
+    add_library(shadowhook STATIC ${SHADOWHOOK_SOURCES})
+    target_include_directories(shadowhook PUBLIC
+        ${SHADOWHOOK_SRC}
+        ${SHADOWHOOK_SRC}/include
+        ${SHADOWHOOK_SRC}/arch/${SHADOWHOOK_ARCH}
+        ${SHADOWHOOK_SRC}/common
+        ${SHADOWHOOK_SRC}/third_party/xdl
+        ${SHADOWHOOK_SRC}/third_party/bsd
+        ${SHADOWHOOK_SRC}/third_party/lss
+    )
+    target_compile_options(shadowhook PRIVATE
+        -Wno-unused-parameter
+        -Wno-unused-but-set-variable
+        -Wno-unused-variable
+        -Wno-unused-function
+    )
+endif ()
+
 add_subdirectory(dobby)
 add_subdirectory(fmt)
 add_subdirectory(lsplant/lsplant/src/main/jni)

--- a/external/README.md
+++ b/external/README.md
@@ -8,6 +8,9 @@ They are included as git submodules to ensure version consistency and timely upd
 -   [Dobby](https://github.com/JingMatrix/Dobby): 
     A lightweight, multi-platform inline hooking framework. It serves as the backend for all native function hooking (`HookInline`).
 
+-   [ShadowHook](https://github.com/bytedance/android-inline-hook): 
+    ShadowHook is an Android inline hook library. It also serves as the backend for all native function hooking (`HookInline`).
+
 -   [fmt](https://github.com/fmtlib/fmt):
     A modern formatting library used for high-performance, type-safe logging throughout the native code.
 
@@ -28,3 +31,7 @@ They are included as git submodules to ensure version consistency and timely upd
 -   [axml/manifest-editor](https://github.com/JingMatrix/ManifestEditor):
     A a tool used to modify Android Manifest binary file. It is to parse manifestation files of Xposed modules.
 
+## Patches
+
+-   [patches/shadowhook](patches/shadowhook):
+    Used to bypass detection by `libshadowhook_nothing.so`.

--- a/external/patches/shadowhook/sh_linker.c
+++ b/external/patches/shadowhook/sh_linker.c
@@ -1,0 +1,953 @@
+// Copyright (c) 2021-2025 ByteDance Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+// Created by Kelun Cai (caikelun@bytedance.com) on 2021-04-11.
+
+#include "sh_linker.h"
+
+#include <dlfcn.h>
+#include <pthread.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/system_properties.h>
+
+#include "queue.h"
+#include "sh_log.h"
+#include "sh_recorder.h"
+#include "sh_sig.h"
+#include "sh_switch.h"
+#include "sh_util.h"
+#include "sh_xdl.h"
+#include "shadowhook.h"
+#include "xdl.h"
+
+#ifndef __LP64__
+#define SH_LINKER_BASENAME           "linker"
+#define SH_LINKER_ABI_STR            "armeabi-v7a"
+#define SH_LINKER_SIZEOF_DLINFO      16
+#define SH_LINKER_HOOK_WITH_DL_MUTEX 1
+#else
+#define SH_LINKER_BASENAME           "linker64"
+#define SH_LINKER_ABI_STR            "arm64-v8a"
+#define SH_LINKER_SIZEOF_DLINFO      32
+#define SH_LINKER_HOOK_WITH_DL_MUTEX 0
+#endif
+
+#define SH_LINKER_SHADOWHOOK_BASE_NAME         "libshadowhook.so"
+#define SH_LINKER_SHADOWHOOK_NOTHING_BASE_NAME "libshadowhook_nothing.so"
+
+// for struct soinfo's memory scan
+static size_t sh_linker_soinfo_offset_load_bias = SIZE_MAX;
+static size_t sh_linker_soinfo_offset_name = SIZE_MAX;
+static size_t sh_linker_soinfo_offset_phdr = SIZE_MAX;
+static size_t sh_linker_soinfo_offset_phnum = SIZE_MAX;
+static size_t sh_linker_soinfo_offset_constructors_called = SIZE_MAX;
+static pid_t sh_linker_soinfo_offset_scan_tid = 0;
+static bool sh_linker_soinfo_offset_scan_ok = false;
+
+// >= Android 5.0. hook soinfo::call_constructors() and soinfo::call_destructors()
+#define SH_LINKER_SYM_CALL_CONSTRUCTORS_L "__dl__ZN6soinfo16CallConstructorsEv"
+#define SH_LINKER_SYM_CALL_DESTRUCTORS_L  "__dl__ZN6soinfo15CallDestructorsEv"
+#define SH_LINKER_SYM_CALL_CONSTRUCTORS_M "__dl__ZN6soinfo17call_constructorsEv"
+#define SH_LINKER_SYM_CALL_DESTRUCTORS_M  "__dl__ZN6soinfo16call_destructorsEv"
+#if SH_LINKER_HOOK_WITH_DL_MUTEX
+#define SH_LINKER_SYM_G_DL_MUTEX        "__dl__ZL10g_dl_mutex"
+#define SH_LINKER_SYM_G_DL_MUTEX_U_QPR2 "__dl_g_dl_mutex"
+#endif
+
+// >= Android 5.0. soinfo::call_constructors() and soinfo::call_destructors() callbacks
+typedef struct sh_linker_dl_info_cb {
+  shadowhook_dl_info_t pre;
+  shadowhook_dl_info_t post;
+  void *data;
+  TAILQ_ENTRY(sh_linker_dl_info_cb, ) link;
+} sh_linker_dl_info_cb_t;
+typedef TAILQ_HEAD(sh_linker_dl_info_cb_queue, sh_linker_dl_info_cb, ) sh_linker_dl_info_cb_queue_t;
+static sh_linker_dl_info_cb_queue_t sh_linker_dl_init_cbs = TAILQ_HEAD_INITIALIZER(sh_linker_dl_init_cbs);
+static pthread_rwlock_t sh_linker_dl_init_cbs_lock = PTHREAD_RWLOCK_INITIALIZER;
+static sh_linker_dl_info_cb_queue_t sh_linker_dl_fini_cbs = TAILQ_HEAD_INITIALIZER(sh_linker_dl_fini_cbs);
+static pthread_rwlock_t sh_linker_dl_fini_cbs_lock = PTHREAD_RWLOCK_INITIALIZER;
+
+#ifdef SH_CONFIG_COMPATIBLE_WITH_ARM_ANDROID_4_X
+
+// == Android 4.x. for dlopen() interceptor and post-callback
+static bool sh_linker_dlopen_hook_tried = false;
+static sh_linker_dlopen_post_t sh_linker_dlopen_post;
+
+// == Android 4.x
+static uintptr_t sh_linker_dlfcn[6];
+static const char *sh_linker_dlfcn_name[6] = {"dlopen", "dlerror", "dlsym",
+                                              "dladdr", "dlclose", "dl_unwind_find_exidx"};
+__attribute__((constructor)) static void sh_linker_ctor(void) {
+  // Android 4.x linker does not export these symbols. We save the addresses of these
+  // functions in the .init_array to reduce the probability of being PLT-hooked.
+  // The purpose of the negation operation(~) is to avoid being optimized by the compiler.
+  sh_linker_dlfcn[0] = ~(uintptr_t)dlopen;
+  sh_linker_dlfcn[1] = ~(uintptr_t)dlerror;
+  sh_linker_dlfcn[2] = ~(uintptr_t)dlsym;
+  sh_linker_dlfcn[3] = ~(uintptr_t)dladdr;
+  sh_linker_dlfcn[4] = ~(uintptr_t)dlclose;
+  sh_linker_dlfcn[5] = ~(uintptr_t)dl_unwind_find_exidx;
+}
+
+#endif
+
+static const char *sh_linker_match_dlfcn(uintptr_t target_addr) {
+#ifdef SH_CONFIG_COMPATIBLE_WITH_ARM_ANDROID_4_X
+  if (__predict_false(sh_util_get_api_level() < __ANDROID_API_L__))
+    for (size_t i = 0; i < sizeof(sh_linker_dlfcn) / sizeof(sh_linker_dlfcn[0]); i++)
+      if (~sh_linker_dlfcn[i] == target_addr) return sh_linker_dlfcn_name[i];
+#else
+  (void)target_addr;
+#endif
+
+  return NULL;
+}
+
+static void *sh_linker_get_base_addr(xdl_info_t *dlinfo) {
+  uintptr_t vaddr_min = UINTPTR_MAX;
+  for (size_t i = 0; i < dlinfo->dlpi_phnum; i++) {
+    const ElfW(Phdr) *phdr = &(dlinfo->dlpi_phdr[i]);
+    if (PT_LOAD == phdr->p_type && vaddr_min > phdr->p_vaddr) vaddr_min = phdr->p_vaddr;
+  }
+
+  if (UINTPTR_MAX == vaddr_min)
+    return dlinfo->dli_fbase;  // should not happen
+  else
+    return (void *)((uintptr_t)dlinfo->dli_fbase + sh_util_page_start(vaddr_min));
+}
+
+static bool sh_linker_check_arch(xdl_info_t *dlinfo) {
+  ElfW(Ehdr) *ehdr = (ElfW(Ehdr) *)sh_linker_get_base_addr(dlinfo);
+
+#if defined(__LP64__)
+#define SH_LINKER_ELF_CLASS   ELFCLASS64
+#define SH_LINKER_ELF_MACHINE EM_AARCH64
+#else
+#define SH_LINKER_ELF_CLASS   ELFCLASS32
+#define SH_LINKER_ELF_MACHINE EM_ARM
+#endif
+
+  if (0 != memcmp(ehdr->e_ident, ELFMAG, SELFMAG)) return false;
+  if (SH_LINKER_ELF_CLASS != ehdr->e_ident[EI_CLASS]) return false;
+  if (SH_LINKER_ELF_MACHINE != ehdr->e_machine) return false;
+
+  return true;
+}
+
+#ifdef SH_CONFIG_COMPATIBLE_WITH_ARM_ANDROID_4_X
+
+typedef void *(*sh_linker_proxy_dlopen_t)(const char *, int);
+static sh_linker_proxy_dlopen_t sh_linker_orig_dlopen;
+static void *sh_linker_proxy_dlopen(const char *filename, int flag) {
+  void *handle = sh_linker_orig_dlopen(filename, flag);
+  if (NULL != handle) sh_linker_dlopen_post();
+  return handle;
+}
+
+int sh_linker_register_dlopen_post_callback(sh_linker_dlopen_post_t post) {
+  static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+  static int result = SHADOWHOOK_ERRNO_MONITOR_DLOPEN;
+
+  if (sh_linker_dlopen_hook_tried) return result;
+  pthread_mutex_lock(&lock);
+  if (sh_linker_dlopen_hook_tried) goto end;
+
+  sh_linker_dlopen_hook_tried = true;  // only once
+  sh_linker_dlopen_post = post;
+
+  // get dlinfo
+  void *handle = sh_xdl_open(SH_LINKER_BASENAME);
+  if (__predict_false(NULL == handle || SH_XDL_CRASH == handle)) goto end;
+  xdl_info_t dlinfo;
+  xdl_info(handle, XDL_DI_DLINFO, &dlinfo);
+  xdl_close(handle);
+
+  // check arch
+  if (!sh_linker_check_arch(&dlinfo)) {
+    result = SHADOWHOOK_ERRNO_LINKER_ARCH_MISMATCH;
+    goto end;
+  }
+
+  sh_addr_info_t addr_info;
+  addr_info.dli_fbase = dlinfo.dli_fbase;
+  addr_info.dli_fname = SH_LINKER_BASENAME;
+  addr_info.dlpi_phdr = dlinfo.dlpi_phdr;
+  addr_info.dlpi_phnum = dlinfo.dlpi_phnum;
+  addr_info.is_sym_addr = true;
+  addr_info.is_proc_start = true;
+  addr_info.dli_saddr = (void *)~sh_linker_dlfcn[0];
+  addr_info.dli_ssize = 4;
+
+  // do hook
+  sh_recorder_trace_t trace = SH_RECORDER_TRACE_INITIALIZER;
+  int r =
+      sh_switch_hook_invisible((uintptr_t)addr_info.dli_saddr, &addr_info, (uintptr_t)sh_linker_proxy_dlopen,
+                               (uintptr_t *)&sh_linker_orig_dlopen, &trace);
+
+  // do record
+  sh_recorder_add_op(r, SH_RECORDER_OP_HOOK_INVISIBLE_SYM_ADDR, (uintptr_t)addr_info.dli_saddr,
+                     SH_LINKER_BASENAME, sh_linker_dlfcn_name[0], (uintptr_t)sh_linker_proxy_dlopen,
+                     SHADOWHOOK_HOOK_DEFAULT, UINTPTR_MAX, 0, SH_LINKER_SHADOWHOOK_BASE_NAME, &trace);
+  if (0 != r) goto end;
+
+  // OK
+  result = 0;
+
+end:
+  pthread_mutex_unlock(&lock);
+  SH_LOG_INFO("linker: hook dlopen %s, return: %d", 0 == result ? "OK" : "FAILED", result);
+  return result;
+}
+#endif
+
+// struct soinfo {
+//  // ......
+//  const ElfW(Phdr)* phdr;
+//  size_t phnum;
+//  // ......
+//  // from: link_map link_map_head;
+//  ElfW(Addr) l_addr;
+//  char* l_name;
+//  ElfW(Dyn)* l_ld;
+//  struct link_map* l_next;
+//  struct link_map* l_prev;
+//
+//  bool constructors_called;
+//  ElfW(Addr) load_bias;
+//  // ......
+//};
+static int sh_linker_soinfo_memory_scan_pre(void *soinfo) {
+  void *handle = xdl_open(SH_LINKER_SHADOWHOOK_NOTHING_BASE_NAME, XDL_DEFAULT);
+  if (NULL == handle) {
+    SH_LOG_ERROR("linker: memory_scan_pre, NULL == handle");
+    return -1;
+  }
+
+  xdl_info_t dlinfo;
+  xdl_info(handle, XDL_DI_DLINFO, (void *)&dlinfo);
+
+  uintptr_t l_ld = UINTPTR_MAX;
+  for (size_t i = 0; i < dlinfo.dlpi_phnum; i++) {
+    if (dlinfo.dlpi_phdr[i].p_type == PT_DYNAMIC) {
+      l_ld = (uintptr_t)dlinfo.dli_fbase + dlinfo.dlpi_phdr[i].p_vaddr;
+      break;
+    }
+  }
+  if (UINTPTR_MAX == l_ld) {
+    SH_LOG_ERROR("linker: memory_scan_pre, UINTPTR_MAX == l_ld");
+    goto end;
+  }
+
+  //  SH_LOG_INFO("linker scan: %"PRIxPTR", %"PRIxPTR", %"PRIxPTR", %zu, %s", (uintptr_t)dlinfo.dli_fbase,
+  //              l_ld, (uintptr_t)dlinfo.dlpi_phdr, dlinfo.dlpi_phnum, dlinfo.dli_fname);
+  //  for (size_t i = 0; i < sizeof(uintptr_t) * 96; i += sizeof(uintptr_t))
+  //    SH_LOG_INFO("linker scan: %zu - %"PRIxPTR, i, *((uintptr_t *)((uintptr_t)soinfo + i)));
+
+  for (size_t i = 0; i < sizeof(uintptr_t) * 96; i += sizeof(uintptr_t)) {
+    if (sh_linker_soinfo_offset_phdr != SIZE_MAX && sh_linker_soinfo_offset_load_bias != SIZE_MAX)
+      break;  // finished
+
+    uintptr_t val_0;
+    uintptr_t val_1;
+    uintptr_t val_2;
+    uintptr_t val_3;
+    uintptr_t val_4;
+    uintptr_t val_5;
+    uintptr_t val_6;
+    SH_SIG_TRY(SIGSEGV, SIGBUS) {
+      val_0 = *((uintptr_t *)((uintptr_t)soinfo + i));
+      val_1 = *((uintptr_t *)((uintptr_t)soinfo + i + sizeof(uintptr_t)));
+      val_2 = *((uintptr_t *)((uintptr_t)soinfo + i + sizeof(uintptr_t) * 2));
+      val_3 = *((uintptr_t *)((uintptr_t)soinfo + i + sizeof(uintptr_t) * 3));
+      val_4 = *((uintptr_t *)((uintptr_t)soinfo + i + sizeof(uintptr_t) * 4));
+      val_5 = *((uintptr_t *)((uintptr_t)soinfo + i + sizeof(uintptr_t) * 5));
+      val_6 = *((uintptr_t *)((uintptr_t)soinfo + i + sizeof(uintptr_t) * 6));
+    }
+    SH_SIG_CATCH() {
+      SH_LOG_ERROR("linker: memory_scan_pre, read val_0...val_6 crashed");
+      goto end;
+    }
+    SH_SIG_EXIT
+
+    if (sh_linker_soinfo_offset_phdr == SIZE_MAX && val_0 == (uintptr_t)dlinfo.dlpi_phdr &&
+        val_1 == (uintptr_t)dlinfo.dlpi_phnum) {
+      sh_linker_soinfo_offset_phdr = i;
+      sh_linker_soinfo_offset_phnum = i + sizeof(uintptr_t);
+      i += sizeof(uintptr_t);
+      continue;
+    }
+
+    if (sh_linker_soinfo_offset_load_bias == SIZE_MAX && val_0 == (uintptr_t)dlinfo.dli_fbase &&
+        val_2 == l_ld && val_5 == 0 && val_6 == val_0) {
+      bool l_name_matched = false;
+      SH_SIG_TRY(SIGSEGV, SIGBUS) {
+        l_name_matched = sh_util_ends_with((const char *)val_1, SH_LINKER_SHADOWHOOK_NOTHING_BASE_NAME);
+#if __ANDROID_API__ <= __ANDROID_API_M__
+        if (!l_name_matched && sh_util_get_api_level() == __ANDROID_API_M__) {
+          if (sh_util_ends_with((const char *)val_1, ".apk") &&
+              sh_util_starts_with(dlinfo.dli_fname, (const char *)val_1)) {
+            l_name_matched = true;
+          }
+        }
+#endif
+      }
+      SH_SIG_CATCH() {
+        l_name_matched = false;
+      }
+      SH_SIG_EXIT
+
+      if (l_name_matched) {
+        sh_linker_soinfo_offset_load_bias = i;
+        sh_linker_soinfo_offset_name = i + sizeof(uintptr_t);
+        sh_linker_soinfo_offset_constructors_called = i + sizeof(uintptr_t) * 5;
+        i += sizeof(uintptr_t) * 6;
+        continue;
+      }
+    }
+
+    if (val_0 != (uintptr_t)dlinfo.dlpi_phdr && val_0 != (uintptr_t)dlinfo.dli_fbase &&
+        val_1 != (uintptr_t)dlinfo.dlpi_phdr && val_1 != (uintptr_t)dlinfo.dli_fbase &&
+        val_2 != (uintptr_t)dlinfo.dlpi_phdr && val_2 != (uintptr_t)dlinfo.dli_fbase &&
+        val_3 != (uintptr_t)dlinfo.dlpi_phdr && val_3 != (uintptr_t)dlinfo.dli_fbase &&
+        val_4 != (uintptr_t)dlinfo.dlpi_phdr && val_4 != (uintptr_t)dlinfo.dli_fbase &&
+        val_5 != (uintptr_t)dlinfo.dlpi_phdr && val_5 != (uintptr_t)dlinfo.dli_fbase &&
+        val_6 != (uintptr_t)dlinfo.dlpi_phdr && val_6 != (uintptr_t)dlinfo.dli_fbase) {
+      // try to avoid reading data repeatedly, to reduce the number of calls to "bytesig try-catch"
+      i += sizeof(uintptr_t) * 6;
+    }
+  }
+
+end:
+  if (NULL != handle) xdl_close(handle);
+  if (sh_linker_soinfo_offset_load_bias == SIZE_MAX || sh_linker_soinfo_offset_name == SIZE_MAX ||
+      sh_linker_soinfo_offset_phdr == SIZE_MAX || sh_linker_soinfo_offset_phnum == SIZE_MAX ||
+      sh_linker_soinfo_offset_constructors_called == SIZE_MAX) {
+    SH_LOG_ERROR("linker: memory_scan_pre, check offsets FAILED, %zu, %zu, %zu, %zu, %zu",
+                 sh_linker_soinfo_offset_load_bias, sh_linker_soinfo_offset_name,
+                 sh_linker_soinfo_offset_phdr, sh_linker_soinfo_offset_phnum,
+                 sh_linker_soinfo_offset_constructors_called);
+    return -1;
+  }
+
+  SH_LOG_INFO("linker: soinfo memory scan pre OK. load_bias %zu, name %zu, phdr %zu, phnum %zu, called %zu",
+              sh_linker_soinfo_offset_load_bias, sh_linker_soinfo_offset_name, sh_linker_soinfo_offset_phdr,
+              sh_linker_soinfo_offset_phnum, sh_linker_soinfo_offset_constructors_called);
+  return 0;
+}
+
+static void sh_linker_soinfo_memory_scan_post(void *soinfo) {
+  uintptr_t val = *((uintptr_t *)((uintptr_t)soinfo + sh_linker_soinfo_offset_constructors_called));
+  if (val != 0) {
+    __atomic_store_n(&sh_linker_soinfo_offset_scan_ok, true, __ATOMIC_RELEASE);
+    SH_LOG_INFO("linker: soinfo memory scan post OK");
+  } else {
+    SH_LOG_ERROR("linker: memory_scan_post, check val != 0 FAILED");
+  }
+}
+
+static void sh_linker_soinfo_to_dlinfo(void *soinfo, struct dl_phdr_info *dlinfo, char *fixed_name,
+                                       size_t fixed_name_len) {
+  dlinfo->dlpi_addr = *((ElfW(Addr) *)((uintptr_t)soinfo + sh_linker_soinfo_offset_load_bias));
+  dlinfo->dlpi_name = *((const char **)((uintptr_t)soinfo + sh_linker_soinfo_offset_name));
+  dlinfo->dlpi_phdr = *((const ElfW(Phdr) **)((uintptr_t)soinfo + sh_linker_soinfo_offset_phdr));
+  dlinfo->dlpi_phnum = (ElfW(Half))(*((size_t *)((uintptr_t)soinfo + sh_linker_soinfo_offset_phnum)));
+
+#if __ANDROID_API__ <= __ANDROID_API_M__
+  if (sh_util_get_api_level() == __ANDROID_API_M__ && NULL != fixed_name &&
+      sh_util_ends_with(dlinfo->dlpi_name, ".apk")) {
+    // find .dynamic
+    ElfW(Dyn) *dynamic = NULL;
+    for (size_t i = 0; i < dlinfo->dlpi_phnum; i++) {
+      const ElfW(Phdr) *phdr = &(dlinfo->dlpi_phdr[i]);
+      if (PT_DYNAMIC == phdr->p_type) {
+        dynamic = (ElfW(Dyn) *)(dlinfo->dlpi_addr + phdr->p_vaddr);
+        break;
+      }
+    }
+
+    // add '!/lib/<ABI>/<lib_name>' suffix
+    if (NULL != dynamic) {
+      const char *dynstr = NULL;
+      ssize_t soname_off = -1;
+      for (ElfW(Dyn) *entry = dynamic; entry && entry->d_tag != DT_NULL; entry++) {
+        switch (entry->d_tag) {
+          case DT_STRTAB:
+            dynstr = (const char *)(dlinfo->dlpi_addr + entry->d_un.d_ptr);
+            break;
+          case DT_SONAME:
+            soname_off = (ssize_t)entry->d_un.d_val;
+            break;
+          default:
+            break;
+        }
+      }
+      if (NULL != dynstr && soname_off >= 0) {
+        snprintf(fixed_name, fixed_name_len, "%s!/lib/" SH_LINKER_ABI_STR "/%s", dlinfo->dlpi_name,
+                 dynstr + (size_t)soname_off);
+        dlinfo->dlpi_name = fixed_name;
+      }
+    }
+  }
+#else
+  (void)fixed_name, (void)fixed_name_len;
+#endif
+}
+
+static bool sh_linker_soinfo_is_loading(void *soinfo) {
+  return *((int *)((uintptr_t)soinfo + sh_linker_soinfo_offset_constructors_called)) == 0;
+}
+
+typedef void (*sh_linker_proxy_soinfo_call_ctors_t)(void *);
+static sh_linker_proxy_soinfo_call_ctors_t sh_linker_orig_soinfo_call_ctors;
+void shadowhook_proxy_android_linker_soinfo_call_constructors(void *soinfo) {
+  sh_linker_dl_info_cb_t *cb;
+  struct dl_phdr_info dlinfo;
+  bool do_callbacks = false;
+  bool do_memory_scan_pre_ok = false;
+  pid_t scan_tid = __atomic_load_n(&sh_linker_soinfo_offset_scan_tid, __ATOMIC_ACQUIRE);
+#if __ANDROID_API__ <= __ANDROID_API_M__
+  char buf[1024];
+#endif
+
+  if (__predict_true(0 == scan_tid)) {
+    if (__predict_true(__atomic_load_n(&sh_linker_soinfo_offset_scan_ok, __ATOMIC_ACQUIRE))) {
+      if (sh_linker_soinfo_is_loading(soinfo) && !TAILQ_EMPTY(&sh_linker_dl_init_cbs)) {
+        // do pre-callbacks
+        do_callbacks = true;
+#if __ANDROID_API__ <= __ANDROID_API_M__
+        sh_linker_soinfo_to_dlinfo(soinfo, &dlinfo, buf, sizeof(buf));
+#else
+        sh_linker_soinfo_to_dlinfo(soinfo, &dlinfo, NULL, 0);
+#endif
+
+        SH_LOG_INFO("linker: call_ctors pre, load_bias %" PRIxPTR ", name %s", (uintptr_t)dlinfo.dlpi_addr,
+                    dlinfo.dlpi_name);
+        pthread_rwlock_rdlock(&sh_linker_dl_init_cbs_lock);
+        TAILQ_FOREACH(cb, &sh_linker_dl_init_cbs, link) {
+          if (NULL != cb->pre) cb->pre(&dlinfo, SH_LINKER_SIZEOF_DLINFO, cb->data);
+        }
+        pthread_rwlock_unlock(&sh_linker_dl_init_cbs_lock);
+      }
+    }
+  } else {
+    if (__predict_true(gettid() == scan_tid)) {
+      // do pre-memory-scan
+      if (0 == sh_linker_soinfo_memory_scan_pre(soinfo)) do_memory_scan_pre_ok = true;
+    }
+  }
+
+  sh_linker_orig_soinfo_call_ctors(soinfo);
+
+  if (do_callbacks) {
+    // do post-callbacks
+    SH_LOG_INFO("linker: call_ctors post, load_bias %" PRIxPTR ", name %s", (uintptr_t)dlinfo.dlpi_addr,
+                dlinfo.dlpi_name);
+    pthread_rwlock_rdlock(&sh_linker_dl_init_cbs_lock);
+    TAILQ_FOREACH(cb, &sh_linker_dl_init_cbs, link) {
+      if (NULL != cb->post) cb->post(&dlinfo, SH_LINKER_SIZEOF_DLINFO, cb->data);
+    }
+    pthread_rwlock_unlock(&sh_linker_dl_init_cbs_lock);
+  } else {
+    if (__predict_false(do_memory_scan_pre_ok)) {
+      // do post-memory-scan
+      sh_linker_soinfo_memory_scan_post(soinfo);
+    }
+  }
+}
+
+typedef void (*sh_linker_proxy_soinfo_call_dtors_t)(void *);
+static sh_linker_proxy_soinfo_call_dtors_t sh_linker_orig_soinfo_call_dtors;
+void shadowhook_proxy_android_linker_soinfo_call_destructors(void *soinfo) {
+  sh_linker_dl_info_cb_t *cb;
+  struct dl_phdr_info dlinfo;
+  bool do_callbacks = false;
+#if __ANDROID_API__ <= __ANDROID_API_M__
+  char buf[1024];
+#endif
+
+  if (__predict_true(0 == __atomic_load_n(&sh_linker_soinfo_offset_scan_tid, __ATOMIC_ACQUIRE))) {
+    if (__predict_true(__atomic_load_n(&sh_linker_soinfo_offset_scan_ok, __ATOMIC_ACQUIRE))) {
+      if (!TAILQ_EMPTY(&sh_linker_dl_init_cbs)) {
+#if __ANDROID_API__ <= __ANDROID_API_M__
+        sh_linker_soinfo_to_dlinfo(soinfo, &dlinfo, buf, sizeof(buf));
+#else
+        sh_linker_soinfo_to_dlinfo(soinfo, &dlinfo, NULL, 0);
+#endif
+
+        // The following check is used to ignore: soinfo::call_destructors() call
+        // when the linker encounters an error while loading the ELF.
+        if (__predict_true(0 != dlinfo.dlpi_addr && NULL != dlinfo.dlpi_name &&
+                           !sh_linker_soinfo_is_loading(soinfo))) {
+          // do pre-callbacks
+          do_callbacks = true;
+
+          SH_LOG_INFO("linker: call_dtors pre, load_bias %" PRIxPTR ", name %s", (uintptr_t)dlinfo.dlpi_addr,
+                      dlinfo.dlpi_name);
+          pthread_rwlock_rdlock(&sh_linker_dl_fini_cbs_lock);
+          TAILQ_FOREACH(cb, &sh_linker_dl_fini_cbs, link) {
+            if (NULL != cb->pre) cb->pre(&dlinfo, SH_LINKER_SIZEOF_DLINFO, cb->data);
+          }
+          pthread_rwlock_unlock(&sh_linker_dl_fini_cbs_lock);
+        }
+      }
+    }
+  }
+
+  sh_linker_orig_soinfo_call_dtors(soinfo);
+
+  if (do_callbacks) {
+    // do post-callbacks
+    SH_LOG_INFO("linker: call_dtors post, load_bias %" PRIxPTR ", name %s", (uintptr_t)dlinfo.dlpi_addr,
+                dlinfo.dlpi_name);
+    pthread_rwlock_rdlock(&sh_linker_dl_fini_cbs_lock);
+    TAILQ_FOREACH(cb, &sh_linker_dl_fini_cbs, link) {
+      if (NULL != cb->post) cb->post(&dlinfo, SH_LINKER_SIZEOF_DLINFO, cb->data);
+    }
+    pthread_rwlock_unlock(&sh_linker_dl_fini_cbs_lock);
+  }
+}
+
+static int sh_linker_hook_call_ctors_dtors(sh_addr_info_t *call_ctors_addr_info,
+                                           sh_addr_info_t *call_dtors_addr_info,
+                                           pthread_mutex_t *g_dl_mutex) {
+  int r = -1;
+  int r_hook_ctors = INT_MAX;
+  int r_hook_dtors = INT_MAX;
+  sh_recorder_trace_t trace_ctors = SH_RECORDER_TRACE_INITIALIZER;
+  sh_recorder_trace_t trace_dtors = SH_RECORDER_TRACE_INITIALIZER;
+  int api_level = sh_util_get_api_level();
+
+#if !SH_LINKER_HOOK_WITH_DL_MUTEX
+  (void)g_dl_mutex;
+#endif
+
+#if SH_LINKER_HOOK_WITH_DL_MUTEX
+  pthread_mutex_lock(g_dl_mutex);
+#endif
+
+  // hook soinfo::call_constructors()
+  SH_LOG_INFO("linker: hook(invisible) soinfo::call_constructors");
+  r_hook_ctors = sh_switch_hook_invisible((uintptr_t)call_ctors_addr_info->dli_saddr, call_ctors_addr_info,
+                                          (uintptr_t)shadowhook_proxy_android_linker_soinfo_call_constructors,
+                                          (uintptr_t *)&sh_linker_orig_soinfo_call_ctors, &trace_ctors);
+  if (__predict_false(0 != r_hook_ctors)) {
+#if SH_LINKER_HOOK_WITH_DL_MUTEX
+    pthread_mutex_unlock(g_dl_mutex);
+#endif
+    goto end;
+  }
+
+  // hook soinfo::call_destructors()
+  SH_LOG_INFO("linker: hook(invisible) soinfo::call_destructors");
+  r_hook_dtors = sh_switch_hook_invisible((uintptr_t)call_dtors_addr_info->dli_saddr, call_dtors_addr_info,
+                                          (uintptr_t)shadowhook_proxy_android_linker_soinfo_call_destructors,
+                                          (uintptr_t *)&sh_linker_orig_soinfo_call_dtors, &trace_dtors);
+  if (__predict_false(0 != r_hook_dtors)) {
+#if SH_LINKER_HOOK_WITH_DL_MUTEX
+    pthread_mutex_unlock(g_dl_mutex);
+#endif
+    goto end;
+  }
+
+#if SH_LINKER_HOOK_WITH_DL_MUTEX
+  pthread_mutex_unlock(g_dl_mutex);
+#endif
+
+  // do memory scan for struct soinfo
+  __atomic_store_n(&sh_linker_soinfo_offset_scan_tid, gettid(), __ATOMIC_RELEASE);
+  void *handle = dlopen(SH_LINKER_SHADOWHOOK_NOTHING_BASE_NAME, RTLD_NOW);
+  if (__predict_true(NULL != handle)) dlclose(handle);
+  __atomic_store_n(&sh_linker_soinfo_offset_scan_tid, 0, __ATOMIC_RELEASE);
+  if (__predict_false(NULL == handle)) {
+    SH_LOG_ERROR("linker: dlopen nothing.so FAILED");
+    goto end;
+  }
+  if (__predict_false(!__atomic_load_n(&sh_linker_soinfo_offset_scan_ok, __ATOMIC_ACQUIRE))) {
+    SH_LOG_ERROR("linker: check soinfo_offset_scan_ok FAILED");
+    goto end;
+  }
+
+  // OK
+  r = 0;
+
+end:
+  // do records
+  if (INT_MAX != r_hook_ctors)
+    sh_recorder_add_op(r_hook_ctors, SH_RECORDER_OP_HOOK_INVISIBLE_SYM_ADDR,
+                       (uintptr_t)call_ctors_addr_info->dli_saddr, SH_LINKER_BASENAME,
+                       api_level >= __ANDROID_API_M__ ? SH_LINKER_SYM_CALL_CONSTRUCTORS_M
+                                                      : SH_LINKER_SYM_CALL_CONSTRUCTORS_L,
+                       (uintptr_t)shadowhook_proxy_android_linker_soinfo_call_constructors,
+                       SHADOWHOOK_HOOK_DEFAULT, UINTPTR_MAX, 0, SH_LINKER_SHADOWHOOK_BASE_NAME, &trace_ctors);
+  if (INT_MAX != r_hook_dtors)
+    sh_recorder_add_op(
+        r_hook_dtors, SH_RECORDER_OP_HOOK_INVISIBLE_SYM_ADDR, (uintptr_t)call_dtors_addr_info->dli_saddr,
+        SH_LINKER_BASENAME,
+        api_level >= __ANDROID_API_M__ ? SH_LINKER_SYM_CALL_DESTRUCTORS_M : SH_LINKER_SYM_CALL_DESTRUCTORS_L,
+        (uintptr_t)shadowhook_proxy_android_linker_soinfo_call_destructors, SHADOWHOOK_HOOK_DEFAULT,
+        UINTPTR_MAX, 0, SH_LINKER_SHADOWHOOK_BASE_NAME, &trace_dtors);
+
+  SH_LOG_INFO("linker: hook ctors and dtors %s", 0 == r ? "OK" : "FAILED");
+  return r;
+}
+
+static int sh_linker_get_symbol_info(sh_addr_info_t *call_ctors_addr_info,
+                                     sh_addr_info_t *call_dtors_addr_info, pthread_mutex_t **g_dl_mutex) {
+  int api_level = sh_util_get_api_level();
+
+  void *handle = sh_xdl_open(SH_LINKER_BASENAME);
+  if (__predict_false(NULL == handle || SH_XDL_CRASH == handle)) return -1;
+  int r = -1;
+
+  // check arch
+  xdl_info_t linker_dlinfo;
+  xdl_info(handle, XDL_DI_DLINFO, &linker_dlinfo);
+  if (__predict_false(!sh_linker_check_arch(&linker_dlinfo))) goto end;
+
+  // get soinfo::call_constructors()
+  call_ctors_addr_info->dli_fbase = linker_dlinfo.dli_fbase;
+  call_ctors_addr_info->dli_fname = SH_LINKER_BASENAME;
+  call_ctors_addr_info->dlpi_phdr = linker_dlinfo.dlpi_phdr;
+  call_ctors_addr_info->dlpi_phnum = linker_dlinfo.dlpi_phnum;
+  call_ctors_addr_info->is_sym_addr = true;
+  call_ctors_addr_info->is_proc_start = true;
+  call_ctors_addr_info->dli_saddr = xdl_dsym(
+      handle,
+      api_level >= __ANDROID_API_M__ ? SH_LINKER_SYM_CALL_CONSTRUCTORS_M : SH_LINKER_SYM_CALL_CONSTRUCTORS_L,
+      &(call_ctors_addr_info->dli_ssize));
+  if (__predict_false(NULL == call_ctors_addr_info->dli_saddr)) goto end;
+
+  // get soinfo::call_destructors()
+  call_dtors_addr_info->dli_fbase = linker_dlinfo.dli_fbase;
+  call_dtors_addr_info->dli_fname = SH_LINKER_BASENAME;
+  call_dtors_addr_info->dlpi_phdr = linker_dlinfo.dlpi_phdr;
+  call_dtors_addr_info->dlpi_phnum = linker_dlinfo.dlpi_phnum;
+  call_dtors_addr_info->is_sym_addr = true;
+  call_dtors_addr_info->is_proc_start = true;
+  call_dtors_addr_info->dli_saddr = xdl_dsym(
+      handle,
+      api_level >= __ANDROID_API_M__ ? SH_LINKER_SYM_CALL_DESTRUCTORS_M : SH_LINKER_SYM_CALL_DESTRUCTORS_L,
+      &(call_dtors_addr_info->dli_ssize));
+  if (__predict_false(NULL == call_dtors_addr_info->dli_saddr)) goto end;
+
+#if SH_LINKER_HOOK_WITH_DL_MUTEX
+  // get g_dl_mutex
+  if (api_level > __ANDROID_API_U__) {
+    *g_dl_mutex = (pthread_mutex_t *)(xdl_dsym(handle, SH_LINKER_SYM_G_DL_MUTEX_U_QPR2, NULL));
+  } else if (api_level == __ANDROID_API_U__) {
+    *g_dl_mutex = (pthread_mutex_t *)(xdl_dsym(handle, SH_LINKER_SYM_G_DL_MUTEX, NULL));
+    if (NULL == *g_dl_mutex && api_level == __ANDROID_API_U__)
+      *g_dl_mutex = (pthread_mutex_t *)(xdl_dsym(handle, SH_LINKER_SYM_G_DL_MUTEX_U_QPR2, NULL));
+  } else {
+    *g_dl_mutex = (pthread_mutex_t *)(xdl_dsym(handle, SH_LINKER_SYM_G_DL_MUTEX, NULL));
+  }
+  if (__predict_false(NULL == *g_dl_mutex)) goto end;
+#else
+  (void)g_dl_mutex;
+#endif
+
+  // OK
+  r = 0;
+
+end:
+  xdl_close(handle);
+  return r;
+}
+
+int sh_linker_init(void) {
+  return 0;
+}
+
+int sh_linker_register_dl_init_callback(shadowhook_dl_info_t pre, shadowhook_dl_info_t post, void *data) {
+  sh_linker_dl_info_cb_t *cb_new = malloc(sizeof(sh_linker_dl_info_cb_t));
+  if (NULL == cb_new) return SHADOWHOOK_ERRNO_OOM;
+  cb_new->pre = pre;
+  cb_new->post = post;
+  cb_new->data = data;
+
+  sh_linker_dl_info_cb_t *cb = NULL;
+  pthread_rwlock_wrlock(&sh_linker_dl_init_cbs_lock);
+  TAILQ_FOREACH(cb, &sh_linker_dl_init_cbs, link) {
+    if (cb->pre == pre && cb->post == post && cb->data == data) break;
+  }
+  if (NULL == cb) {
+    TAILQ_INSERT_TAIL(&sh_linker_dl_init_cbs, cb_new, link);
+    cb_new = NULL;
+  }
+  pthread_rwlock_unlock(&sh_linker_dl_init_cbs_lock);
+
+  if (NULL != cb_new) {
+    free(cb_new);
+    return SHADOWHOOK_ERRNO_DUP;
+  }
+  return 0;
+}
+
+int sh_linker_unregister_dl_init_callback(shadowhook_dl_info_t pre, shadowhook_dl_info_t post, void *data) {
+  sh_linker_dl_info_cb_t *cb = NULL, *cb_tmp;
+  pthread_rwlock_wrlock(&sh_linker_dl_init_cbs_lock);
+  TAILQ_FOREACH_SAFE(cb, &sh_linker_dl_init_cbs, link, cb_tmp) {
+    if (cb->pre == pre && cb->post == post && cb->data == data) {
+      TAILQ_REMOVE(&sh_linker_dl_init_cbs, cb, link);
+      break;
+    }
+  }
+  pthread_rwlock_unlock(&sh_linker_dl_init_cbs_lock);
+
+  if (NULL == cb) return SHADOWHOOK_ERRNO_NOT_FOUND;
+  free(cb);
+  return 0;
+}
+
+int sh_linker_register_dl_fini_callback(shadowhook_dl_info_t pre, shadowhook_dl_info_t post, void *data) {
+  sh_linker_dl_info_cb_t *cb_new = malloc(sizeof(sh_linker_dl_info_cb_t));
+  if (NULL == cb_new) return SHADOWHOOK_ERRNO_OOM;
+  cb_new->pre = pre;
+  cb_new->post = post;
+  cb_new->data = data;
+
+  sh_linker_dl_info_cb_t *cb = NULL;
+  pthread_rwlock_wrlock(&sh_linker_dl_fini_cbs_lock);
+  TAILQ_FOREACH(cb, &sh_linker_dl_fini_cbs, link) {
+    if (cb->pre == pre && cb->post == post && cb->data == data) break;
+  }
+  if (NULL == cb) {
+    TAILQ_INSERT_TAIL(&sh_linker_dl_fini_cbs, cb_new, link);
+    cb_new = NULL;
+  }
+  pthread_rwlock_unlock(&sh_linker_dl_fini_cbs_lock);
+
+  if (NULL != cb_new) {
+    free(cb_new);
+    return SHADOWHOOK_ERRNO_DUP;
+  }
+  return 0;
+}
+
+int sh_linker_unregister_dl_fini_callback(shadowhook_dl_info_t pre, shadowhook_dl_info_t post, void *data) {
+  sh_linker_dl_info_cb_t *cb = NULL, *cb_tmp;
+  pthread_rwlock_wrlock(&sh_linker_dl_fini_cbs_lock);
+  TAILQ_FOREACH_SAFE(cb, &sh_linker_dl_fini_cbs, link, cb_tmp) {
+    if (cb->pre == pre && cb->post == post && cb->data == data) {
+      TAILQ_REMOVE(&sh_linker_dl_fini_cbs, cb, link);
+      break;
+    }
+  }
+  pthread_rwlock_unlock(&sh_linker_dl_fini_cbs_lock);
+
+  if (NULL == cb) return SHADOWHOOK_ERRNO_NOT_FOUND;
+  free(cb);
+  return 0;
+}
+
+int sh_linker_get_addr_info_by_addr(sh_addr_info_t *addr_info, void *addr, bool is_sym_addr,
+                                    bool is_proc_start, bool ignore_sym_info) {
+  sh_linker_free_addr_info(addr_info);
+  memset(addr_info, 0, sizeof(sh_addr_info_t));
+
+  // dladdr()
+  int r = 0;
+  void *dlcache = NULL;
+  bool crashed = false;
+  xdl_info_t dlinfo;
+  memset(&dlinfo, 0, sizeof(xdl_info_t));
+  if (sh_util_get_api_level() >= __ANDROID_API_L__) {
+    r = xdl_addr4(addr, &dlinfo, &dlcache, ignore_sym_info ? XDL_NON_SYM : XDL_DEFAULT);
+  } else {
+    SH_SIG_TRY(SIGSEGV, SIGBUS) {
+      r = xdl_addr4(addr, &dlinfo, &dlcache, ignore_sym_info ? XDL_NON_SYM : XDL_DEFAULT);
+    }
+    SH_SIG_CATCH() {
+      crashed = true;
+    }
+    SH_SIG_EXIT
+  }
+  SH_LOG_INFO(
+      "linker: get dlinfo by target addr: target_addr %p, sym_name %s, sym_sz %zu, load_bias %" PRIxPTR
+      ", pathname %s",
+      addr, NULL == dlinfo.dli_sname ? "(NULL)" : dlinfo.dli_sname, dlinfo.dli_ssize,
+      (uintptr_t)dlinfo.dli_fbase, NULL == dlinfo.dli_fname ? "(NULL)" : dlinfo.dli_fname);
+
+  // check error
+  if (crashed) {
+    r = SHADOWHOOK_ERRNO_HOOK_DLADDR_CRASH;
+    goto end;
+  }
+  if (0 == r || NULL == dlinfo.dli_fbase) {
+    r = SHADOWHOOK_ERRNO_HOOK_DLINFO;
+    goto end;
+  }
+  if (!sh_linker_check_arch(&dlinfo)) {
+    r = SHADOWHOOK_ERRNO_ELF_ARCH_MISMATCH;
+    goto end;
+  }
+
+  if (!ignore_sym_info && 0 == dlinfo.dli_saddr) {
+    const char *matched_dlfcn_name = sh_linker_match_dlfcn((uintptr_t)addr);
+    if (NULL == matched_dlfcn_name) {
+      r = SHADOWHOOK_ERRNO_HOOK_DLINFO;
+      goto end;
+    }
+    dlinfo.dli_saddr = addr;
+    dlinfo.dli_ssize = 4;  // safe length, only relative jumps are allowed
+    SH_LOG_INFO("linker: match dlfcn, target_addr %p, sym_name %s", addr, matched_dlfcn_name);
+  }
+
+  // OK
+  if (NULL != dlinfo.dli_fname) {
+    if (NULL == (addr_info->dli_fname = strdup(dlinfo.dli_fname))) return SHADOWHOOK_ERRNO_OOM;
+  }
+  addr_info->dli_fbase = dlinfo.dli_fbase;
+  addr_info->dli_saddr = dlinfo.dli_saddr;
+  addr_info->dli_ssize = dlinfo.dli_ssize;
+  addr_info->dlpi_phdr = dlinfo.dlpi_phdr;
+  addr_info->dlpi_phnum = dlinfo.dlpi_phnum;
+  addr_info->is_sym_addr = is_sym_addr;
+  addr_info->is_proc_start = is_proc_start;
+  r = 0;
+
+end:
+  xdl_addr_clean(&dlcache);
+  return r;
+}
+
+int sh_linker_get_addr_info_by_name(sh_addr_info_t *addr_info, const char *lib_name, const char *sym_name) {
+  sh_linker_free_addr_info(addr_info);
+  memset(addr_info, 0, sizeof(sh_addr_info_t));
+
+  // open library
+  void *handle = sh_xdl_open(lib_name);
+  if (SH_XDL_CRASH == handle) return SHADOWHOOK_ERRNO_HOOK_DLOPEN_CRASH;
+  if (NULL == handle) return SHADOWHOOK_ERRNO_PENDING;
+
+  // get dlinfo
+  xdl_info_t dlinfo;
+  xdl_info(handle, XDL_DI_DLINFO, (void *)&dlinfo);
+
+  // check error
+  if (!sh_linker_check_arch(&dlinfo)) {
+    xdl_close(handle);
+    return SHADOWHOOK_ERRNO_ELF_ARCH_MISMATCH;
+  }
+
+  // lookup symbol address
+  size_t sym_size = 0;
+  void *sym_addr = sh_xdl_sym(handle, sym_name, &sym_size);
+
+  // close library
+  xdl_close(handle);
+
+  if (SH_XDL_CRASH == sym_addr) return SHADOWHOOK_ERRNO_HOOK_DLSYM_CRASH;
+  if (NULL == sym_addr) return SHADOWHOOK_ERRNO_HOOK_DLSYM;
+
+  if (NULL == (addr_info->dli_fname = strdup(lib_name))) return SHADOWHOOK_ERRNO_OOM;
+  addr_info->dli_fbase = dlinfo.dli_fbase;
+  addr_info->dli_saddr = sym_addr;
+  addr_info->dli_ssize = sym_size;
+  addr_info->dlpi_phdr = dlinfo.dlpi_phdr;
+  addr_info->dlpi_phnum = dlinfo.dlpi_phnum;
+  addr_info->is_sym_addr = true;
+  addr_info->is_proc_start = true;
+  return 0;
+}
+
+int sh_linker_get_addr_info_by_handle(sh_addr_info_t *addr_info, void **cached_handle,
+                                      struct dl_phdr_info *info, const char *sym_name) {
+  sh_linker_free_addr_info(addr_info);
+  memset(addr_info, 0, sizeof(sh_addr_info_t));
+
+  // open library
+  void *handle;
+  if (NULL != *cached_handle) {
+    handle = *cached_handle;
+  } else {
+    handle = xdl_open2(info);
+    if (NULL == handle) return SHADOWHOOK_ERRNO_OOM;
+  }
+
+  // get dlinfo
+  xdl_info_t dlinfo;
+  xdl_info(handle, XDL_DI_DLINFO, (void *)&dlinfo);
+
+  // check error
+  if (!sh_linker_check_arch(&dlinfo)) {
+    xdl_close(handle);
+    return SHADOWHOOK_ERRNO_ELF_ARCH_MISMATCH;
+  }
+
+  *cached_handle = handle;
+
+  // lookup symbol address
+  size_t sym_size = 0;
+  void *sym_addr = sh_xdl_sym(handle, sym_name, &sym_size);
+  if (SH_XDL_CRASH == sym_addr) return SHADOWHOOK_ERRNO_HOOK_DLSYM_CRASH;
+  if (NULL == sym_addr) return SHADOWHOOK_ERRNO_HOOK_DLSYM;
+
+  if (NULL != dlinfo.dli_fname) {
+    if (NULL == (addr_info->dli_fname = strdup(dlinfo.dli_fname))) return SHADOWHOOK_ERRNO_OOM;
+  }
+  addr_info->dli_fbase = dlinfo.dli_fbase;
+  addr_info->dli_saddr = sym_addr;
+  addr_info->dli_ssize = sym_size;
+  addr_info->dlpi_phdr = dlinfo.dlpi_phdr;
+  addr_info->dlpi_phnum = dlinfo.dlpi_phnum;
+  addr_info->is_sym_addr = true;
+  addr_info->is_proc_start = true;
+  return 0;
+}
+
+void sh_linker_close_handle(void *cached_handle) {
+  if (NULL != cached_handle) xdl_close(cached_handle);
+}
+
+void sh_linker_free_addr_info(sh_addr_info_t *addr_info) {
+  if (NULL != addr_info->dli_fname) {
+    free(addr_info->dli_fname);
+    addr_info->dli_fname = NULL;
+  }
+}
+
+int sh_linker_copy_addr_info(sh_addr_info_t *addr_info, sh_addr_info_t *copy) {
+  memcpy(copy, addr_info, sizeof(sh_addr_info_t));
+  if (NULL != addr_info->dli_fname) {
+    copy->dli_fname = strdup(addr_info->dli_fname);
+    if (NULL == copy->dli_fname) return SHADOWHOOK_ERRNO_OOM;
+  }
+  return 0;
+}
+
+bool sh_linker_is_addr_in_elf_pt_load(uintptr_t addr, void *dli_fbase, const ElfW(Phdr) *dlpi_phdr,
+                                      size_t dlpi_phnum) {
+  if (addr < (uintptr_t)dli_fbase) return false;
+
+  uintptr_t vaddr = addr - (uintptr_t)dli_fbase;
+  for (size_t i = 0; i < dlpi_phnum; i++) {
+    const ElfW(Phdr) *phdr = &dlpi_phdr[i];
+    if (PT_LOAD != phdr->p_type) continue;
+
+    if (phdr->p_vaddr <= vaddr && vaddr < phdr->p_vaddr + phdr->p_memsz) return true;
+  }
+
+  return false;
+}

--- a/manager/src/debug/kotlin/org/matrix/vector/manager/demo/FakeManagerService.kt
+++ b/manager/src/debug/kotlin/org/matrix/vector/manager/demo/FakeManagerService.kt
@@ -305,6 +305,13 @@ class FakeManagerService(
 
     override fun setIncludeNewApps(packageName: String?, enable: Boolean): Boolean =
         real?.setIncludeNewApps(packageName, enable) ?: false
+
+    override fun getInlineHookBackend(): Int =
+        real?.inlineHookBackend ?: IManagerService.INLINE_HOOK_BACKEND_DOBBY
+
+    override fun setInlineHookBackend(backend: Int) {
+        real?.setInlineHookBackend(backend)
+    }
 }
 
 /**

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ipc/DaemonClient.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ipc/DaemonClient.kt
@@ -349,6 +349,12 @@ class DaemonClient(private val serviceState: StateFlow<IManagerService?>) {
 
     suspend fun getRootImplementation(): Result<Int> = runIpc { it.rootImplementation }
 
+    suspend fun getInlineHookBackend(): Result<Int> = runIpc { it.inlineHookBackend }
+
+    suspend fun setInlineHookBackend(backend: Int): Result<Unit> = runIpc {
+        it.setInlineHookBackend(backend)
+    }
+
     /**
      * Starts a flash and returns as soon as the daemon has accepted it.
      *

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/home/HomeViewModel.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/home/HomeViewModel.kt
@@ -209,6 +209,9 @@ class HomeViewModel(
     private val _statusNotification = MutableStateFlow(true)
     val statusNotification: StateFlow<Boolean> = _statusNotification.asStateFlow()
 
+    private val _inlineHookBackend = MutableStateFlow(IManagerService.INLINE_HOOK_BACKEND_DOBBY)
+    val inlineHookBackend: StateFlow<Int> = _inlineHookBackend.asStateFlow()
+
     // True is the platform's own default for `show_hidden_icon_apps_enabled`, so the switch shows
     // what the system is doing on a device where nobody has touched it rather than reading "off"
     // until the daemon answers.
@@ -546,6 +549,10 @@ class HomeViewModel(
                 }
             }
             .onFailure { e -> logW("status: notification toggle unread", e) }
+        daemon
+            .getInlineHookBackend()
+            .onSuccess { _inlineHookBackend.value = it }
+            .onFailure { e -> logW("status: inline hook backend unread", e) }
         // Read rather than assumed: this one is a global system setting, so anything on the device
         // can have moved it since the manager last wrote it.
         daemon
@@ -582,6 +589,17 @@ class HomeViewModel(
                 // so a transaction that arrived is not yet a setting that changed.
                 _hiddenIcon.value = daemon.isForcedLauncherIcons().getOrDefault(force)
             }
+        }
+    }
+
+    fun setInlineHookBackend(backend: Int) {
+        viewModelScope.launch {
+            daemon
+                .setInlineHookBackend(backend)
+                .onSuccess { _inlineHookBackend.value = backend }
+                .onFailure { e ->
+                    logE("framework: setting the inline hook backend to $backend failed", e)
+                }
         }
     }
 

--- a/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/home/SystemStatusScreen.kt
+++ b/manager/src/main/kotlin/org/matrix/vector/manager/ui/screens/home/SystemStatusScreen.kt
@@ -28,6 +28,9 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
@@ -97,6 +100,7 @@ fun SystemStatusScreen(
     val context = LocalContext.current
     val statusNotification by viewModel.statusNotification.collectAsStateWithLifecycle()
     val hiddenIcon by viewModel.hiddenIcon.collectAsStateWithLifecycle()
+    val inlineHookBackend by viewModel.inlineHookBackend.collectAsStateWithLifecycle()
     val presence by viewModel.presence.collectAsStateWithLifecycle()
     val managerInstall by viewModel.managerInstall.collectAsStateWithLifecycle()
 
@@ -226,6 +230,14 @@ fun SystemStatusScreen(
                     checked = hiddenIcon,
                     enabled = daemonAlive,
                     onCheckedChange = viewModel::setForcedLauncherIcons,
+                )
+            }
+            item {
+                InlineHookBackendSetting(
+                    backend = inlineHookBackend,
+                    shadowHookSupported = isShadowHookSupported(device.abi),
+                    enabled = daemonAlive,
+                    onSelect = viewModel::setInlineHookBackend,
                 )
             }
 
@@ -886,6 +898,81 @@ private fun FrameworkToggle(
         }
         Spacer(Modifier.width(12.dp))
         Switch(checked = checked, onCheckedChange = null, enabled = enabled)
+    }
+}
+
+private fun isShadowHookSupported(abi: String): Boolean =
+    abi == "arm64-v8a" || abi == "armeabi-v7a"
+
+/**
+ * The engine that installs native inline hooks, chosen from the engines this device ships.
+ *
+ * ShadowHook is only built for arm ABIs, so on any other device the row reports Dobby alone and
+ * explains why rather than offering a choice that could not be honoured. Dimmed and inert while
+ * there is no daemon, for the same reason as [FrameworkToggle].
+ */
+@Composable
+private fun InlineHookBackendSetting(
+    backend: Int,
+    shadowHookSupported: Boolean,
+    enabled: Boolean,
+    onSelect: (Int) -> Unit,
+) {
+    val colors = MaterialTheme.colorScheme
+    val engineCount = if (shadowHookSupported) 2 else 1
+    Column(
+        modifier =
+            Modifier.fillMaxWidth()
+                .padding(vertical = 10.dp)
+                .alpha(if (enabled) 1f else 0.38f),
+    ) {
+        Text(stringResource(R.string.inline_hook_backend), style = MaterialTheme.typography.bodyLarge)
+        Text(
+            stringResource(R.string.inline_hook_backend_summary),
+            style = MaterialTheme.typography.bodySmall,
+            color = colors.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(8.dp))
+        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+            SegmentedButton(
+                selected = backend == IManagerService.INLINE_HOOK_BACKEND_DOBBY,
+                onClick = { onSelect(IManagerService.INLINE_HOOK_BACKEND_DOBBY) },
+                enabled = enabled,
+                shape = SegmentedButtonDefaults.itemShape(index = 0, count = engineCount),
+                icon = {},
+            ) {
+                Text(
+                    stringResource(R.string.inline_hook_backend_dobby),
+                    style = MaterialTheme.typography.labelLarge,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            if (shadowHookSupported) {
+                SegmentedButton(
+                    selected = backend == IManagerService.INLINE_HOOK_BACKEND_SHADOWHOOK,
+                    onClick = { onSelect(IManagerService.INLINE_HOOK_BACKEND_SHADOWHOOK) },
+                    enabled = enabled,
+                    shape = SegmentedButtonDefaults.itemShape(index = 1, count = engineCount),
+                    icon = {},
+                ) {
+                    Text(
+                        stringResource(R.string.inline_hook_backend_shadowhook),
+                        style = MaterialTheme.typography.labelLarge,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+        }
+        if (!shadowHookSupported) {
+            Spacer(Modifier.height(6.dp))
+            Text(
+                stringResource(R.string.inline_hook_backend_shadowhook_note),
+                style = MaterialTheme.typography.labelMedium,
+                color = colors.onSurfaceVariant,
+            )
+        }
     }
 }
 

--- a/manager/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/src/main/res/values-zh-rCN/strings.xml
@@ -377,6 +377,11 @@
     <string name="crash_unreadable">无法读取这次崩溃。请原样复制并附在报告里。</string>
     <string name="force_launcher_icons">阻止应用隐藏自己的桌面图标</string>
     <string name="force_launcher_icons_summary">从 Android 10 起，隐藏了自己桌面图标的应用会被补上一个图标，点击它会打开该应用的应用信息页面。关闭此项可以让它继续保持隐藏——桌面可能要等重启之后才会更新。本来就没有桌面图标的应用不受影响，大多数模块都属于此类。</string>
+    <string name="inline_hook_backend">内联 Hook 后端</string>
+    <string name="inline_hook_backend_summary">用于安装原生内联 Hook 的引擎。新启动的进程会使用所选引擎；重启后会对所有进程生效。</string>
+    <string name="inline_hook_backend_dobby">Dobby</string>
+    <string name="inline_hook_backend_shadowhook">ShadowHook</string>
+    <string name="inline_hook_backend_shadowhook_note">ShadowHook 仅支持 arm64-v8a 与 armeabi-v7a。</string>
     <string name="action_force_stop_failed">无法停止 %1$s。</string>
     <string name="modules_load_unsupported_api">已启用，但针对 libxposed API 100 构建，此框架已不再加载该版本。</string>
     <string name="update_root_unknown">此框架构建不会报告已安装的是哪一种 root 实现。</string>

--- a/manager/src/main/res/values-zh-rTW/strings.xml
+++ b/manager/src/main/res/values-zh-rTW/strings.xml
@@ -377,6 +377,11 @@
     <string name="crash_unreadable">無法讀取這次當機。請原樣複製並附在回報中。</string>
     <string name="force_launcher_icons">阻止應用程式隱藏自己的啟動器圖示</string>
     <string name="force_launcher_icons_summary">自 Android 10 起，隱藏了自己啟動器圖示的應用程式會被補上一個圖示，點按它會開啟該應用程式的應用程式資訊頁面。關閉此項可讓它維持隱藏——你的啟動器可能要等重新啟動之後才會更新。本來就沒有啟動器圖示的應用程式不受影響，大多數模組都屬於此類。</string>
+    <string name="inline_hook_backend">內聯 Hook 後端</string>
+    <string name="inline_hook_backend_summary">用於安裝原生內聯 Hook 的引擎。新啟動的行程會使用所選引擎；重新啟動後會對所有行程生效。</string>
+    <string name="inline_hook_backend_dobby">Dobby</string>
+    <string name="inline_hook_backend_shadowhook">ShadowHook</string>
+    <string name="inline_hook_backend_shadowhook_note">ShadowHook 僅支援 arm64-v8a 與 armeabi-v7a。</string>
     <string name="action_force_stop_failed">無法停止 %1$s。</string>
     <string name="modules_load_unsupported_api">已啟用，但針對 libxposed API 100 建置，此框架已不再載入該版本。</string>
     <string name="update_root_unknown">此框架建置不會回報已安裝的是哪一種 root 實作。</string>

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -92,6 +92,11 @@
     <string name="status_notification_summary">A persistent notification showing that Vector is running.</string>
     <string name="force_launcher_icons">Stop apps hiding their launcher icons</string>
     <string name="force_launcher_icons_summary">Since Android 10, an app that hides its own launcher icon gets one back that opens its app info page. Turn this off to let it stay hidden — your launcher may not catch up until it restarts. Apps that never had a launcher icon, including most modules, are unaffected.</string>
+    <string name="inline_hook_backend">Inline hook backend</string>
+    <string name="inline_hook_backend_summary">Which engine installs native inline hooks. New processes use the chosen engine; a reboot applies it to everything already running.</string>
+    <string name="inline_hook_backend_dobby">Dobby</string>
+    <string name="inline_hook_backend_shadowhook">ShadowHook</string>
+    <string name="inline_hook_backend_shadowhook_note">ShadowHook is only available on arm64-v8a and armeabi-v7a.</string>
     <!-- Home: the community feed -->
     <string name="home_quarter_title">Recent activity</string>
     <!-- Example: "7 commits by 4 people" -->

--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -36,13 +36,18 @@ target_compile_options(${PROJECT_NAME} PRIVATE -Wpedantic ${IGNORED_WARNINGS})
 # Link against required external and system libraries.
 # PUBLIC libraries are propagated to targets that link against this one.
 # PRIVATE libraries are only used for the compilation of this target.
-target_link_libraries(${PROJECT_NAME} PUBLIC
+set(VECTOR_NATIVE_LINK_LIBS
     dobby_static
     lsplant_static
     xz_static
     log # Android logging library
     fmt-header-only
 )
+if (ANDROID_ABI STREQUAL "arm64-v8a" OR ANDROID_ABI STREQUAL "armeabi-v7a")
+    set(VECTOR_NATIVE_LINK_LIBS ${VECTOR_NATIVE_LINK_LIBS} shadowhook)
+endif ()
+
+target_link_libraries(${PROJECT_NAME} PUBLIC ${VECTOR_NATIVE_LINK_LIBS})
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
     dex_builder_static

--- a/native/include/core/native_api.h
+++ b/native/include/core/native_api.h
@@ -1,8 +1,15 @@
 #pragma once
 
 #include <dlfcn.h>
+#if defined(__aarch64__) || defined(__arm__)
+#include <shadowhook.h>
+#endif
 #include <dobby.h>
 
+#include <atomic>
+#include <cstdint>
+#include <map>
+#include <mutex>
 #include <string>
 #include <utils/hook_helper.hpp>
 
@@ -91,6 +98,69 @@ struct NativeAPIEntries {
 
 namespace vector::native {
 
+inline constexpr int kInlineHookBackendDobby = 0;
+inline constexpr int kInlineHookBackendShadowHook = 1;
+
+inline std::atomic<int> g_inline_hook_backend{kInlineHookBackendDobby};
+
+inline void SetInlineHookBackend(int backend) {
+#if defined(__aarch64__) || defined(__arm__)
+    backend =
+        backend == kInlineHookBackendShadowHook ? kInlineHookBackendShadowHook : kInlineHookBackendDobby;
+#else
+    backend = kInlineHookBackendDobby;
+#endif
+    g_inline_hook_backend.store(backend, std::memory_order_relaxed);
+    LOGD("Inline hook backend set to {}",
+         backend == kInlineHookBackendShadowHook ? "ShadowHook" : "Dobby");
+}
+
+#if defined(__aarch64__) || defined(__arm__)
+inline std::once_flag g_shadowhook_init_once;
+inline int g_shadowhook_init_result = -1;
+inline std::mutex g_shadowhook_mutex;
+inline std::map<uintptr_t, void *> g_shadowhook_stubs;
+
+inline bool shadowhookInit() {
+    std::call_once(g_shadowhook_init_once, [] {
+        g_shadowhook_init_result = shadowhook_init(SHADOWHOOK_MODE_UNIQUE, false);
+        if (g_shadowhook_init_result == 0) {
+            LOGD("ShadowHook engine ready. (mode: unique)");
+        } else {
+            LOGE("ShadowHook init failed: %s",
+                 shadowhook_to_errmsg(shadowhook_get_init_errno()));
+        }
+    });
+    return g_shadowhook_init_result == 0;
+}
+#endif
+
+inline void logHookedSymbol(int backend, void *address) {
+    if constexpr (kIsDebugBuild) {
+        Dl_info info;
+        if (dladdr(address, &info)) {
+            LOGD("{} hooking {} ({}) from {} ({})",
+                 backend == kInlineHookBackendShadowHook ? "ShadowHook" : "Dobby",
+                 info.dli_sname ? info.dli_sname : "(unknown symbol)",
+                 info.dli_saddr ? info.dli_saddr : address,
+                 info.dli_fname ? info.dli_fname : "(unknown file)", info.dli_fbase);
+        }
+    }
+}
+
+inline void logUnhookedSymbol(int backend, void *address) {
+    if constexpr (kIsDebugBuild) {
+        Dl_info info;
+        if (dladdr(address, &info)) {
+            LOGD("{} unhooking {} ({}) from {} ({})",
+                 backend == kInlineHookBackendShadowHook ? "ShadowHook" : "Dobby",
+                 info.dli_sname ? info.dli_sname : "(unknown symbol)",
+                 info.dli_saddr ? info.dli_saddr : address,
+                 info.dli_fname ? info.dli_fname : "(unknown file)", info.dli_fbase);
+        }
+    }
+}
+
 // The entry point function that native modules must export (`native_init`).
 using NativeInit = NativeOnModuleLoaded (*)(const NativeAPIEntries *entries);
 
@@ -112,35 +182,56 @@ bool InstallNativeAPI(const lsplant::HookHandler &handler);
 void RegisterNativeLib(const std::string &library_name);
 
 /**
- * @brief A wrapper around DobbyHook.
+ * @brief A wrapper around the configured inline hook backend.
  */
 inline int HookInline(void *original, void *replace, void **backup) {
-    if constexpr (kIsDebugBuild) {
-        Dl_info info;
-        if (dladdr(original, &info)) {
-            LOGD("Dobby hooking {} ({}) from {} ({})",
-                 info.dli_sname ? info.dli_sname : "(unknown symbol)",
-                 info.dli_saddr ? info.dli_saddr : original,
-                 info.dli_fname ? info.dli_fname : "(unknown file)", info.dli_fbase);
+#if defined(__aarch64__) || defined(__arm__)
+    if (g_inline_hook_backend.load(std::memory_order_relaxed) == kInlineHookBackendShadowHook) {
+        if (shadowhookInit()) {
+            logHookedSymbol(kInlineHookBackendShadowHook, original);
+            void *stub = shadowhook_hook_func_addr(original, replace, backup);
+            if (stub != nullptr) {
+                std::lock_guard<std::mutex> lk(g_shadowhook_mutex);
+                g_shadowhook_stubs[reinterpret_cast<uintptr_t>(original)] = stub;
+                return 0;
+            }
+            LOGE("Inline Hook with ShadowHook failed: %s (%p), falling back to Dobby",
+                 shadowhook_to_errmsg(shadowhook_get_errno()), original);
         }
     }
+#endif
+    logHookedSymbol(kInlineHookBackendDobby, original);
     return DobbyHook(original, reinterpret_cast<dobby_dummy_func_t>(replace),
                      reinterpret_cast<dobby_dummy_func_t *>(backup));
 }
 
 /**
- * @brief A wrapper around DobbyDestroy.
+ * @brief A wrapper around the configured inline hook backend.
  */
 inline int UnhookInline(void *original) {
-    if constexpr (kIsDebugBuild) {
-        Dl_info info;
-        if (dladdr(original, &info)) {
-            LOGD("Dobby unhooking {} ({}) from {} ({})",
-                 info.dli_sname ? info.dli_sname : "(unknown symbol)",
-                 info.dli_saddr ? info.dli_saddr : original,
-                 info.dli_fname ? info.dli_fname : "(unknown file)", info.dli_fbase);
+#if defined(__aarch64__) || defined(__arm__)
+    if (g_inline_hook_backend.load(std::memory_order_relaxed) == kInlineHookBackendShadowHook) {
+        void *stub = nullptr;
+        {
+            std::lock_guard<std::mutex> lk(g_shadowhook_mutex);
+            auto it = g_shadowhook_stubs.find(reinterpret_cast<uintptr_t>(original));
+            if (it != g_shadowhook_stubs.end()) {
+                stub = it->second;
+                g_shadowhook_stubs.erase(it);
+            }
+        }
+        if (stub != nullptr) {
+            if (shadowhook_unhook(stub) == 0) {
+                logUnhookedSymbol(kInlineHookBackendShadowHook, original);
+                return 0;
+            }
+            LOGE("Inline Unhook with ShadowHook failed: %s (%p)",
+                 shadowhook_to_errmsg(shadowhook_get_errno()), original);
+            return -1;
         }
     }
+#endif
+    logUnhookedSymbol(kInlineHookBackendDobby, original);
     return DobbyDestroy(original);
 }
 

--- a/services/manager-service/src/main/aidl/org/matrix/vector/ipc/IManagerService.aidl
+++ b/services/manager-service/src/main/aidl/org/matrix/vector/ipc/IManagerService.aidl
@@ -730,6 +730,23 @@ interface IManagerService {
     @nullable ParcelFileDescriptor getManagerApk();
 
     /**
+     * Which engine installs native inline hooks, one of the INLINE_HOOK_BACKEND_* constants.
+     */
+    int getInlineHookBackend();
+
+    /**
+     * Sets that. Dobby is available on every ABI; ShadowHook is built for arm64-v8a and
+     * armeabi-v7a only. Processes already running keep the engine they started with.
+     */
+    void setInlineHookBackend(int backend);
+
+    /** The Dobby inline hook engine. */
+    const int INLINE_HOOK_BACKEND_DOBBY = 0;
+
+    /** The ShadowHook inline hook engine. */
+    const int INLINE_HOOK_BACKEND_SHADOWHOOK = 1;
+
+    /**
      * The daemon did not say which root implementation is installed.
      *
      * <p>Takes 0 because 0 is also what a binder proxy hands back for a transaction the daemon does

--- a/zygisk/src/main/cpp/include/ipc_bridge.h
+++ b/zygisk/src/main/cpp/include/ipc_bridge.h
@@ -82,6 +82,14 @@ public:
     std::map<std::string, std::string> FetchObfuscationMap(JNIEnv *env, jobject binder);
 
     /**
+     * @brief Fetches the configured inline hook backend via the provided Binder.
+     * @param env JNI environment pointer.
+     * @param binder A live Binder connection to the host service.
+     * @return The backend id, or -1 when the value could not be fetched.
+     */
+    int FetchInlineHookBackend(JNIEnv *env, jobject binder);
+
+    /**
      * @brief Sets up the JNI hook to intercept Binder transactions.
      *
      * This is the core of the IPC interception mechanism.

--- a/zygisk/src/main/cpp/ipc_bridge.cpp
+++ b/zygisk/src/main/cpp/ipc_bridge.cpp
@@ -89,6 +89,7 @@ constexpr auto kBridgeServiceName = "activity"sv;
 constexpr jint kBridgeTransactionCode = ('_' << 24) | ('V' << 16) | ('E' << 8) | 'C';
 constexpr jint kDexTransactionCode = ('_' << 24) | ('D' << 16) | ('E' << 8) | 'X';
 constexpr jint kObfuscationMapTransactionCode = ('_' << 24) | ('O' << 16) | ('B' << 8) | 'F';
+constexpr jint kInlineHookTransactionCode = ('_' << 24) | ('I' << 16) | ('H' << 8) | 'B';
 
 // Action codes sent within a kBridgeTransactionCode transaction.
 constexpr jint kActionGetBinder = 2;
@@ -451,6 +452,33 @@ std::map<std::string, std::string> IPCBridge::FetchObfuscationMap(JNIEnv *env, j
 
     LOGV("Fetched obfuscation map with {} entries.", result_map.size());
     return result_map;
+}
+
+int IPCBridge::FetchInlineHookBackend(JNIEnv *env, jobject binder) {
+    if (!initialized_ || !binder) {
+        return -1;
+    }
+
+    ParcelWrapper parcels(env, this);
+    bool success = lsplant::JNI_CallBooleanMethod(env, binder, transact_method_,
+                                                  kInlineHookTransactionCode, parcels.data.get(),
+                                                  parcels.reply.get(), 0);
+
+    if (!success) {
+        LOGW("Inline hook backend fetch transaction failed.");
+        return -1;
+    }
+
+    lsplant::JNI_CallVoidMethod(env, parcels.reply.get(), read_exception_method_);
+    if (env->ExceptionCheck()) {
+        LOGW("Remote exception received while fetching inline hook backend.");
+        env->ExceptionClear();
+        return -1;
+    }
+
+    int backend = lsplant::JNI_CallIntMethod(env, parcels.reply.get(), read_int_method_);
+    LOGV("Fetched inline hook backend: {}", backend);
+    return backend;
 }
 
 jboolean IPCBridge::ExecTransact_Replace(jboolean *res, JNIEnv *env, jobject obj, va_list args) {

--- a/zygisk/src/main/cpp/module.cpp
+++ b/zygisk/src/main/cpp/module.cpp
@@ -347,6 +347,9 @@ void VectorModule::postAppSpecialize(const zygisk::AppSpecializeArgs *args) {
     auto obfs_map = ipc_bridge.FetchObfuscationMap(env_, binder.get());
     ConfigBridge::GetInstance()->obfuscation_map(std::move(obfs_map));
 
+    auto inline_hook_backend = ipc_bridge.FetchInlineHookBackend(env_, binder.get());
+    vector::native::SetInlineHookBackend(inline_hook_backend);
+
     {
         PreloadedDex dex(dex_fd, dex_size);
         this->LoadDex(env_, std::move(dex));
@@ -441,6 +444,9 @@ void VectorModule::postServerSpecialize(const zygisk::ServerSpecializeArgs *args
 
     auto obfs_map = ipc_bridge.FetchObfuscationMap(env_, effective_binder);
     ConfigBridge::GetInstance()->obfuscation_map(std::move(obfs_map));
+
+    auto inline_hook_backend = ipc_bridge.FetchInlineHookBackend(env_, effective_binder);
+    vector::native::SetInlineHookBackend(inline_hook_backend);
 
     {
         PreloadedDex dex(dex_fd, dex_size);

--- a/zygisk/src/main/kotlin/org/matrix/vector/GrapheneDclHooker.kt
+++ b/zygisk/src/main/kotlin/org/matrix/vector/GrapheneDclHooker.kt
@@ -19,7 +19,7 @@ import org.matrix.vector.util.Utils
  *  2. **Kernel `grapheneos_flags`.** `SELinuxFlags.get` turns the same settings into the
  *     `DENY_EXECMEM`/`DENY_EXECMOD`/… task flags, written to `/proc/self/attr/grapheneos_flags`
  *     during zygote specialization (writable only from the zygote context, so it cannot be undone
- *     later). With `DENY_EXECMEM` set, LSPlant/Dobby cannot allocate executable memory for its
+ *     later). With `DENY_EXECMEM` set, LSPlant/Dobby/ShadowHook cannot allocate executable memory for its
  *     inline hook and the process aborts with `SIGSEGV` / `TSEC_FLAG_DENY_EXECMEM: op denied`.
  *
  * As the manager runs inside [BuildConfig.InjectedPackageName] (`com.android.shell`, a system app)


### PR DESCRIPTION
As Dobby has been inactive for a long time, I added support for switching the inline hook backend; it can now use ByteDance's ShadowHook as the backend.

NOTE: ShadowHook only supports arm64-v8a or armeabi-v7a, so, I designed it to be unavailable when using the x86 architecture.